### PR TITLE
fix moby error on devcontainer build

### DIFF
--- a/.devcontainer/dev.Dockerfile
+++ b/.devcontainer/dev.Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM python:3.13.12-slim
+FROM python:3.13-slim-bookworm
 
 # Install git + optional SSH client for GitHub/Bitbucket, plus minimal build deps
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Last merge introduced a container build error.

Error: (!) The 'moby' option is not supported on Debian 'trixie'... set '"moby": false' or use a different base image (bookworm/ubuntu)
Fix:  switch the base image off trixie
