### PR TITLE
Devcontainer Issue with UV Project Manager

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
     // Mount the Docker socket and feature
     "mounts": [
         "source=${localWorkspaceFolder},target=/app,type=bind,consistency=cached",
-        "source=poetry-cache,target=/root/.cache/pypoetry,type=volume",
+        "source=uv-cache,target=/root/.cache/uv,type=volume",
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
     ],
     "features": {
@@ -21,7 +21,10 @@
             "version": "latest"
         }
     },
-    "postCreateCommand": "poetry install --with dev",
+    "postCreateCommand": "uv sync --extra dev",
+    "remoteEnv": {
+        "PATH": "/app/.venv/bin:${containerEnv:PATH}"
+    },
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.gitignore
+++ b/.gitignore
@@ -70,11 +70,12 @@ output/
 # Environment variables
 .env
 
-# Exclude vscode workspace configuration 
+# Exclude vscode workspace configuration
 # (easier for devs to contribute with same env settings)
 !.vscode/
 
 # ai tools
+CLAUDE.md
 .claude/
 .continue/
 .kilocode/


### PR DESCRIPTION
## Updates
- Update postCreateCommand to use UV instead of removed poetry
- Update stale poetry mount references to use UV
- Update container to point to virtual env created by UV
- Add `CLAUDE.md` to `.gitignore`

# Errors Encountered
```bash
[5688 ms] Start: Run in container: /bin/sh -c poetry install --with dev 
/bin/sh: 1: poetry: not found
[5771 ms] postCreateCommand from devcontainer.json failed with exit code 127. Skipping any
further user-provided commands.
```

```bash
[1660 ms] Error response from daemon: container 05405df1719b3d885a5212e78164e4ae6264e6a92c6cf5aad3bcb40d4d92d34b is not running
  [1660 ms] Start: Run in container:  (command -v getent >/dev/null 2>&1 && getent passwd 'root' || grep -E '^root|^[^:]*:[^:]*:root:' /etc/passwd || true)
  [1660 ms] Stdin closed!
  [1662 ms] Error: An error occurred setting up the container.
  [1662 ms]     at b9 (/Users/alexc/.vscode/extensions/ms-vscode-remote.remote-containers-0.442.0/dist/spec-node/devContainersSpecCLI.js:467:1277)
  [1662 ms]     at mL (/Users/alexc/.vscode/extensions/ms-vscode-remote.remote-containers-0.442.0/dist/spec-node/devContainersSpecCLI.js:467:1021)
  [1662 ms]     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
  [1662 ms]     at async Z9 (/Users/alexc/.vscode/extensions/ms-vscode-remote.remote-containers-0.442.0/dist/spec-node/devContainersSpecCLI.js:485:3870)
  [1662 ms]     at async EC (/Users/alexc/.vscode/extensions/ms-vscode-remote.remote-containers-0.442.0/dist/spec-node/devContainersSpecCLI.js:485:4989)                                                                 [1662 ms]     at async M5 (/Users/alexc/.vscode/extensions/ms-vscode-remote.remote-containers-0.442.0/dist/spec-node/devContainersSpecCLI.js:666:205)
  [1662 ms]     at async k5 (/Users/alexc/.vscode/extensions/ms-vscode-remote.remote-containers-0.442.0/dist/spec-node/devContainersSpecCLI.js:665:15084)
  [1662 ms]     at async /Users/alexc/.vscode/extensions/ms-vscode-remote.remote-containers-0.442.0/dist/spec-node/devContainersSpecCLI.js:485:1188
  [1667 ms] Exit code 1
  [1670 ms] Command failed: /Applications/Visual Studio Code.app/Contents/Frameworks/Code Helper (Plugin).app/Contents/MacOS/Code Helper (Plugin)
  /Users/alexc/.vscode/extensions/ms-vscode-remote.remote-containers-0.442.0/dist/spec-node/devContainersSpecCLI.js up --user-data-folder /Users/alexc/Library/Application
  Support/Code/User/globalStorage/ms-vscode-remote.remote-containers/data --container-session-data-folder /tmp/devcontainers-c1bf9d5b-f33a-4a56-a4c4-71ad9a6cfd181771945870204 --workspace-folder
  /Users/alexc/OMSCS/DCS/repos/dcs-simulation-engine --workspace-mount-consistency cached --gpu-availability detect --id-label devcontainer.local_folder=/Users/alexc/OMSCS/DCS/repos/dcs-simulation-engine
  --id-label devcontainer.config_file=/Users/alexc/OMSCS/DCS/repos/dcs-simulation-engine/.devcontainer/devcontainer.json --log-level debug --log-format json --config
  /Users/alexc/OMSCS/DCS/repos/dcs-simulation-engine/.devcontainer/devcontainer.json --default-user-env-probe loginInteractiveShell --mount type=volume,source=vscode,target=/vscode,external=true
  --skip-post-create --update-remote-user-uid-default on --mount-workspace-git-root --include-configuration --include-merged-configuration
```

```bash
  [4068 ms] Error response from daemon: container 608f640ee68f54b6a7ecdc41ccb90f7d4288a11d8c3ba2ffbfd47032e2374067 is not running
  [4068 ms] Start: Run in container:  (command -v getent >/dev/null 2>&1 && getent passwd 'root' || grep -E '^root|^[^:]*:[^:]*:root:' /etc/passwd || true)
  [4068 ms] Stdin closed!
  [4068 ms] Error: An error occurred setting up the container.
  [4068 ms]     at b9 (/Users/alexc/.vscode/extensions/ms-vscode-remote.remote-containers-0.442.0/dist/spec-node/devContainersSpecCLI.js:467:1277)
  [4068 ms]     at mL (/Users/alexc/.vscode/extensions/ms-vscode-remote.remote-containers-0.442.0/dist/spec-node/devContainersSpecCLI.js:467:1021)
  [4068 ms]     at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
  [4068 ms]     at async Z9 (/Users/alexc/.vscode/extensions/ms-vscode-remote.remote-containers-0.442.0/dist/spec-node/devContainersSpecCLI.js:485:3870)
  [4068 ms]     at async EC (/Users/alexc/.vscode/extensions/ms-vscode-remote.remote-containers-0.442.0/dist/spec-node/devContainersSpecCLI.js:485:4989)
  [4069 ms]     at async M5 (/Users/alexc/.vscode/extensions/ms-vscode-remote.remote-containers-0.442.0/dist/spec-node/devContainersSpecCLI.js:666:205)
  [4069 ms]     at async k5 (/Users/alexc/.vscode/extensions/ms-vscode-remote.remote-containers-0.442.0/dist/spec-node/devContainersSpecCLI.js:665:15084)
  [4069 ms]     at async /Users/alexc/.vscode/extensions/ms-vscode-remote.remote-containers-0.442.0/dist/spec-node/devContainersSpecCLI.js:485:1188
  [4072 ms] Exit code 1
  [4075 ms] Command failed: /Applications/Visual Studio Code.app/Contents/Frameworks/Code Helper (Plugin).app/Contents/MacOS/Code Helper (Plugin)
  /Users/alexc/.vscode/extensions/ms-vscode-remote.remote-containers-0.442.0/dist/spec-node/devContainersSpecCLI.js up --user-data-folder /Users/alexc/Library/Application
  Support/Code/User/globalStorage/ms-vscode-remote.remote-containers/data --container-session-data-folder /tmp/devcontainers-19f2daea-a076-4ed3-8ff2-9d72936f69421771946230625 --workspace-folder
  /Users/alexc/OMSCS/DCS/repos/dcs-simulation-engine --workspace-mount-consistency cached --gpu-availability detect --id-label devcontainer.local_folder=/Users/alexc/OMSCS/DCS/repos/dcs-simulation-engine
  --id-label devcontainer.config_file=/Users/alexc/OMSCS/DCS/repos/dcs-simulation-engine/.devcontainer/devcontainer.json --log-level debug --log-format json --config
  /Users/alexc/OMSCS/DCS/repos/dcs-simulation-engine/.devcontainer/devcontainer.json --default-user-env-probe loginInteractiveShell --remove-existing-container --mount
  type=volume,source=vscode,target=/vscode,external=true --skip-post-create --update-remote-user-uid-default on --mount-workspace-git-root --include-configuration --include-merged-configuration
```