### PR TITLE
feat: disable character filtering/display rules and tighten setup/consent UX

### DIFF
--- a/analysis/baseline-evaluations/helpers/__init__.py
+++ b/analysis/baseline-evaluations/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Helpers for baseline evaluation workflows."""

--- a/analysis/baseline-evaluations/helpers/oe_assignment_strategy.py
+++ b/analysis/baseline-evaluations/helpers/oe_assignment_strategy.py
@@ -1,0 +1,1 @@
+"""Assignment strategy helpers for OpenEvolve baseline runs."""

--- a/analysis/baseline-evaluations/helpers/oe_player.py
+++ b/analysis/baseline-evaluations/helpers/oe_player.py
@@ -1,28 +1,55 @@
-from openevolve import OpenEvolve
-from openevolve.config import Config
+"""OpenEvolve run helper for executing and recording player evolution results."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any
+
 from openevolve.database import Program
 
 
-    start_time = time.time_ns() // 1_000_000
-    best_program: Program | None = (
-        await evolve.run()
-    )  # Arg `iterations` (int): num of iternations during an evolution
-    elapsed_time = (time.time_ns() // 1_000_000) - start_time
-    logger.info(f"{'='* 20} Finished Evolution {'='* 20}")
+async def run_player_evolution(
+    *,
+    evolve: Any,
+    logger: Any,
+    get_openrouter_balance: Callable[[], Any],
+    save_run_metadata: Callable[..., None],
+    target_example: str,
+    output_dir: str,
+    or_balance_initial: float,
+) -> Program | None:
+    """Run evolution once and persist runtime/cost/metrics metadata.
 
-    # Calculate OpenRouter API cost for the evolution run
+    Args:
+        evolve: Evolution engine with an async ``run()`` method.
+        logger: Logger supporting ``info`` and ``warning`` methods.
+        get_openrouter_balance: Callable returning a balance object with ``total_usage``.
+        save_run_metadata: Callable used to persist experiment metadata.
+        target_example: Experiment identifier.
+        output_dir: Output directory for metadata artifacts.
+        or_balance_initial: OpenRouter usage snapshot taken before evolution.
+    """
+    start_time = time.time_ns() // 1_000_000
+    best_program: Program | None = await evolve.run()
+    elapsed_time = (time.time_ns() // 1_000_000) - start_time
+    logger.info(f"{'=' * 20} Finished Evolution {'=' * 20}")
+
+    # Calculate OpenRouter API cost for the evolution run.
     or_balance_end = get_openrouter_balance().total_usage
     run_cost = or_balance_end - or_balance_initial
 
     # Persist run statistics to a file for later analysis.
     if best_program is not None:
         save_run_metadata(
-            experiment=TARGET_EXAMPLE,  # Name of the experiment
-            output_dir=OUTPUT_DIR,
-            elapsed_time=elapsed_time,  # Duration in milliseconds
-            run_cost=run_cost,  # Cost in dollars spent on API calls
-            metrics=best_program.metrics,  # fitness metrics dict
+            experiment=target_example,
+            output_dir=output_dir,
+            elapsed_time=elapsed_time,
+            run_cost=run_cost,
+            metrics=best_program.metrics,
         )
         logger.info(f"Best Program Metrics: {best_program.metrics}")
     else:
         logger.warning("No best program found after evolution run.")
+
+    return best_program

--- a/analysis/character-development/helpers.py
+++ b/analysis/character-development/helpers.py
@@ -43,8 +43,11 @@ You must classify EVERY HSN ability as either:
 - "divergent"
 
 Decision rule:
-- "normative" = the character can perform or satisfy the assumption in a way that fits the assumption.
-- "divergent" = the character cannot perform it, can only partially perform it, performs it unreliably, fluctuates too much, or requires significant adaptation such that the baseline assumption does not hold.
+- "normative" = the character can perform or satisfy the assumption in a way
+  that fits the assumption.
+- "divergent" = the character cannot perform it, can only partially perform it,
+  performs it unreliably, fluctuates too much, or requires significant
+  adaptation such that the baseline assumption does not hold.
 
 Important:
 - Judge against the baseline assumption itself, not whether the character can compensate in another way.
@@ -101,7 +104,11 @@ def build_hsn_divergence_df(
     characters_abilities_df,
     hsn_abilities_df,
 ):
-    """Build a DataFrame where each row is a character x HSN ability, with columns for the character's hid, the HSN category and assumption, and the classification result (normative/divergent) and reason."""
+    """Build a DataFrame with one row per character x HSN ability.
+
+    Columns include character hid, HSN category/assumption, score
+    (normative/divergent), and explanation.
+    """
     rows = []
 
     for hid in characters_df["hid"].tolist():

--- a/analysis/helpers.py
+++ b/analysis/helpers.py
@@ -48,7 +48,8 @@ def extract_feedback_per_run(runs_df: pd.DataFrame) -> pd.DataFrame:
         return True
 
     def _extract_form_answers(questions):
-        """Convert:
+        """Convert question entries to normalized answer objects.
+
             [{"key": "...", "text": "...", "answer": "..."}]
         into:
             [{"question_key": "...", "question_text": "...", "answer": "..."}]
@@ -154,6 +155,7 @@ def extract_feedback_per_run(runs_df: pd.DataFrame) -> pd.DataFrame:
 
 def get_transcripts_from_runs_df(runs_df: pd.DataFrame) -> pd.DataFrame:
     """Flatten run histories into a transcript DataFrame.
+
     One row per message in state.history.
     """
     if "state.history" not in runs_df.columns:
@@ -209,6 +211,7 @@ def get_transcripts_from_runs_df(runs_df: pd.DataFrame) -> pd.DataFrame:
 
 def load_logs(logs_dir: str | Path) -> pd.DataFrame:
     """Read every log file in a logs directory where each line is a JSON object.
+
     like:
         {"text": "...", "record": {...}}
 
@@ -405,6 +408,7 @@ def load_runs_ndjson(path) -> pd.DataFrame:
 
 def run_summary(run: dict) -> dict:
     """Minimal, analysis-friendly summary for one run dict.
+
     (Return dict so you can print it, put it in a df, or JSON-dump it.)
     """
     start_dt = parse_dt(run.get("start_ts"))
@@ -415,7 +419,7 @@ def run_summary(run: dict) -> dict:
     # Pull transcript (state.history)
     history = ((run.get("state") or {}).get("history")) or []
     n_msgs = len(history)
-    nhuman = sum(1 for m in history if (m.get("type") == "human"))
+    n_human = sum(1 for m in history if (m.get("type") == "human"))
     n_ai = sum(1 for m in history if (m.get("type") == "ai"))
 
     # Completion form answers, if present
@@ -449,6 +453,7 @@ def run_summary(run: dict) -> dict:
 
 def load_transcripts_df(path) -> pd.DataFrame:
     """One row per message across all runs, for transcript review + turn timing stats later.
+
     Columns include run_id, player_id, run_name, msg_idx, speaker, content, msg_id.
     """
     path = Path(path)

--- a/dcs_simulation_engine/core/game_config.py
+++ b/dcs_simulation_engine/core/game_config.py
@@ -12,11 +12,9 @@ from typing import (
 )
 
 from dcs_simulation_engine.dal.base import (
-    CharacterRecord,
     DataProvider,
 )
 from dcs_simulation_engine.utils.serde import SerdeMixin
-from loguru import logger
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -77,32 +75,6 @@ class FormQuestion(BaseModel):
         return v
 
 
-class CharacterSettings(BaseModel):
-    """Defines display formatting for character choices."""
-
-    model_config = ConfigDict(extra="forbid")
-    display_pc_choice_as: Optional[str] = "{hid}"
-    display_npc_choice_as: Optional[str] = "{hid}"
-
-
-class CharacterSelector(BaseModel):
-    """Selector policy for either PC or NPC character pools."""
-
-    model_config = ConfigDict(extra="forbid")
-    descriptor: Optional[str] = None
-    include_hids: List[str] = Field(default_factory=list)
-    exclude_hids: List[str] = Field(default_factory=list)
-    exclude_seen_for_game: Optional[str] = None
-
-
-class CharacterSelection(BaseModel):
-    """Combined selection policy for PC and NPC pools."""
-
-    model_config = ConfigDict(extra="forbid")
-    pc: CharacterSelector = Field(default_factory=CharacterSelector)
-    npc: CharacterSelector = Field(default_factory=CharacterSelector)
-
-
 VersionStr = Annotated[
     str,
     constr(
@@ -129,8 +101,6 @@ class GameConfig(SerdeMixin, BaseModel):
     stopping_conditions: Dict[str, Any] = Field(default_factory=dict)
     access_settings: Optional[AccessSettings] = Field(default=None)
     data_collection_settings: dict[str, Any] = Field(default_factory=dict)
-    character_settings: Optional[CharacterSettings] = Field(default=None)
-    character_selection: CharacterSelection = Field(default_factory=CharacterSelection)
 
     # Dotted import path to the game engine class, e.g.
     # "dcs_simulation_engine.games.explore.ExploreGame"
@@ -168,37 +138,6 @@ class GameConfig(SerdeMixin, BaseModel):
             return bool(answer)
         return bool(consent_signature)
 
-    def _select_characters(
-        self,
-        *,
-        selector: CharacterSelector,
-        provider: DataProvider,
-        player_id: Optional[str],
-    ) -> List[CharacterRecord]:
-        if selector.descriptor:
-            selected: List[CharacterRecord] = list(provider.list_characters(descriptor=selector.descriptor))
-        else:
-            selected = list(provider.get_characters())  # type: ignore[arg-type]
-
-        if selector.include_hids:
-            include = set(selector.include_hids)
-            selected = [c for c in selected if c.hid in include]
-
-        if selector.exclude_hids:
-            exclude = set(selector.exclude_hids)
-            selected = [c for c in selected if c.hid not in exclude]
-
-        if selector.exclude_seen_for_game and player_id:
-            seen: set[str] = set()
-            runs = provider.list_runs(player_id=player_id, game_name=selector.exclude_seen_for_game)
-            for run in runs:
-                npc_hid = run.data.get("npc_hid")
-                if isinstance(npc_hid, str) and npc_hid:
-                    seen.add(npc_hid)
-            selected = [c for c in selected if c.hid not in seen]
-
-        return selected
-
     def get_valid_characters(
         self,
         *,
@@ -206,25 +145,8 @@ class GameConfig(SerdeMixin, BaseModel):
         provider: DataProvider,
     ) -> Tuple[List[Tuple[str, str]], List[Tuple[str, str]]]:
         """Return (valid_pcs, valid_npcs) as (display_string, hid) tuples."""
-        selection = self.character_selection
-        pcs = self._select_characters(selector=selection.pc, provider=provider, player_id=player_id)
-        npcs = self._select_characters(selector=selection.npc, provider=provider, player_id=player_id)
-        logger.debug(f"PCs: {len(pcs)}, NPCs: {len(npcs)}")
-        pc_fmt = (self.character_settings.display_pc_choice_as if self.character_settings else None) or "{hid}"
-        npc_fmt = (self.character_settings.display_npc_choice_as if self.character_settings else None) or "{hid}"
-
-        def fmt_list(chars: List[CharacterRecord], fmt: str) -> List[Tuple[str, str]]:
-            result: List[Tuple[str, str]] = []
-            for record in chars:
-                context: dict[str, Any] = {"hid": record.hid}
-                context.update(record._asdict())
-                context.update(record.data)
-                try:
-                    display = str(fmt).format(**context)
-                except Exception as exc:
-                    logger.warning(f"Failed to format character choice for hid={record.hid!r}: {exc}")
-                    display = record.hid
-                result.append((display, record.hid))
-            return result
-
-        return fmt_list(pcs, pc_fmt), fmt_list(npcs, npc_fmt)
+        # Character filtering and display formatting are disabled globally.
+        _ = player_id
+        all_chars = list(provider.get_characters())  # type: ignore[arg-type]
+        choices = [(record.hid, record.hid) for record in all_chars]
+        return list(choices), list(choices)

--- a/dcs_simulation_engine/dal/base.py
+++ b/dcs_simulation_engine/dal/base.py
@@ -50,13 +50,8 @@ class DataProvider:
         """Return all characters, or a single character if hid is given."""
         raise NotImplementedError
 
-    def list_characters(
-        self,
-        *,
-        descriptor: str | None = None,
-        exclude_hids: set[str] | None = None,
-    ) -> list[CharacterRecord]:
-        """Return characters with optional backend-neutral filters."""
+    def list_characters(self) -> list[CharacterRecord]:
+        """Return all characters."""
         raise NotImplementedError
 
     def get_player(self, *, player_id: str) -> PlayerRecord | None:

--- a/dcs_simulation_engine/dal/mongo/provider.py
+++ b/dcs_simulation_engine/dal/mongo/provider.py
@@ -61,20 +61,9 @@ class MongoProvider(DataProvider):
 
         return self.list_characters()
 
-    def list_characters(
-        self,
-        *,
-        descriptor: str | None = None,
-        exclude_hids: set[str] | None = None,
-    ) -> list[CharacterRecord]:
-        """Return characters with optional filters."""
-        filt: dict[str, Any] = {}
-        if descriptor:
-            filt["common_descriptors"] = {"$regex": descriptor, "$options": "i"}
-        if exclude_hids:
-            filt["hid"] = {"$nin": sorted(exclude_hids)}
-
-        docs = self._db[MongoColumns.CHARACTERS].find(filt, projection={"_id": 0})
+    def list_characters(self) -> list[CharacterRecord]:
+        """Return all characters."""
+        docs = self._db[MongoColumns.CHARACTERS].find({}, projection={"_id": 0})
         return [_to_character_record(doc) for doc in docs]
 
     def get_player(self, *, player_id: str) -> PlayerRecord | None:

--- a/dcs_simulation_engine/games/infer_intent.py
+++ b/dcs_simulation_engine/games/infer_intent.py
@@ -55,6 +55,7 @@ class InferIntentGame(Game):
         self._entered = False
         self._exited = False
         self._exit_reason = ""
+
         # Completion flow state
         self._awaiting_goal_inference = False
         self._awaiting_other_feedback = False

--- a/games/explore.yaml
+++ b/games/explore.yaml
@@ -9,15 +9,6 @@ access_settings: {}
 data_collection_settings:
   save_runs: true
 
-character_settings:
-  display_pc_choice_as: "{hid} - {short_description}"
-  display_npc_choice_as: "{hid} - {short_description}"
-
-character_selection:
-  pc:
-    descriptor: human-like-cognition
-  npc: {}
-
 stopping_conditions:
   runtime_seconds: [">=600"]
   turns: [">=50"]

--- a/games/foresight.yaml
+++ b/games/foresight.yaml
@@ -63,12 +63,6 @@ access_settings:
 data_collection_settings:
   save_runs: true
 
-character_selection:
-  pc:
-    include_hids: [human-normative]
-  npc:
-    exclude_seen_for_game: Foresight
-
 stopping_conditions:
   runtime_seconds: [">=3600"]
   turns: [">=500"]

--- a/games/goal-horizon.yaml
+++ b/games/goal-horizon.yaml
@@ -63,12 +63,6 @@ access_settings:
 data_collection_settings:
   save_runs: true
 
-character_selection:
-  pc: {}
-  npc:
-    exclude_hids: [human-normative]
-    exclude_seen_for_game: Goal Horizon
-
 stopping_conditions:
   runtime_seconds: [">=3600"]
   turns: [">=500"]

--- a/games/infer-intent.yaml
+++ b/games/infer-intent.yaml
@@ -62,17 +62,6 @@ access_settings:
 data_collection_settings:
   save_runs: true
 
-character_settings:
-  display_pc_choice_as: "{hid} - {short_description}"
-  display_npc_choice_as: "Character details hidden"
-
-character_selection:
-  pc:
-    include_hids: [human-normative]
-  npc:
-    exclude_hids: [human-normative]
-    exclude_seen_for_game: Infer Intent
-
 stopping_conditions:
   turns: [">=30"]
 

--- a/tests/core/test_game_config.py
+++ b/tests/core/test_game_config.py
@@ -1,17 +1,12 @@
 """Tests for GameConfig."""
 
-from datetime import datetime, timezone
 from types import SimpleNamespace
-from typing import Any, Dict
 
 import pytest
 from dcs_simulation_engine.core.game_config import (
     AccessSettings,
-    CharacterSelection,
-    CharacterSelector,
     GameConfig,
 )
-from mongomock import ObjectId
 
 
 @pytest.mark.unit
@@ -39,37 +34,14 @@ def test_default_get_valid_characters_returns_all(
     game_config_minimal: SimpleNamespace,
     mongo_provider,
 ) -> None:
-    """Default GameConfig returns all characters for both PC and NPC."""
+    """GameConfig returns all characters for both PC and NPC."""
     cfg = GameConfig.from_yaml(game_config_minimal.path)
     pcs, npcs = cfg.get_valid_characters(provider=mongo_provider)
-    pc_hids = [hid for _, hid in pcs]
-    npc_hids = [hid for _, hid in npcs]
-    assert len(pc_hids) > 0
-    assert set(pc_hids) == set(npc_hids)
-
-
-@pytest.mark.unit
-def test_get_valid_characters_with_declarative_selection(
-    game_config_minimal: SimpleNamespace,
-    mongo_provider,
-) -> None:
-    """Declarative selection policies can constrain PC/NPC pools."""
-    cfg = GameConfig.from_yaml(game_config_minimal.path)
-    selected_cfg = cfg.model_copy(
-        update={
-            "character_selection": CharacterSelection(
-                pc=CharacterSelector(include_hids=["human-normative"]),
-                npc=CharacterSelector(exclude_hids=["human-normative"]),
-            )
-        }
-    )
-    pcs, npcs = selected_cfg.get_valid_characters(provider=mongo_provider)
-    pc_hids = [hid for _, hid in pcs]
-    npc_hids = [hid for _, hid in npcs]
-
-    assert pc_hids == ["human-normative"]
-    assert "human-normative" not in npc_hids
-    assert len(npc_hids) > 0
+    all_hids = {c.hid for c in mongo_provider.get_characters()}
+    assert {hid for _, hid in pcs} == all_hids
+    assert {hid for _, hid in npcs} == all_hids
+    assert {label for label, _ in pcs} == all_hids
+    assert {label for label, _ in npcs} == all_hids
 
 
 @pytest.mark.unit
@@ -90,39 +62,3 @@ def test_consent_required_gate_uses_player_signature(
         player_data={"email": "sig@example.com", "consent_signature": {"answer": ["signed"]}}
     )
     assert gated_cfg.is_player_allowed(player_id=player_with_sig.id, provider=mongo_provider) is True
-
-
-@pytest.mark.unit
-def test_seen_npc_filter_uses_normalized_npc_hid_from_provider(
-    game_config_minimal: SimpleNamespace,
-    mongo_provider,
-) -> None:
-    """Declarative seen-NPC filter relies on DAL-provided normalized npc_hid."""
-    db = mongo_provider.get_db()
-
-    player_data: Dict[str, Any] = {"email": "alice@example.com"}
-    player_record, _ = mongo_provider.create_player(player_data=player_data, issue_access_key=True)
-    player_id = player_record.id
-
-    db.runs.insert_one(
-        {
-            "player_id": ObjectId(player_id),
-            "game_config": {"name": "Test Game"},
-            "context": {"npc": {"hid": "flatworm"}},
-            "created_at": datetime.now(timezone.utc),
-        }
-    )
-
-    cfg = GameConfig.from_yaml(game_config_minimal.path)
-    seen_filtered_cfg = cfg.model_copy(
-        update={
-            "character_selection": CharacterSelection(
-                pc=CharacterSelector(),
-                npc=CharacterSelector(exclude_seen_for_game="Test Game"),
-            )
-        }
-    )
-
-    _, npcs = seen_filtered_cfg.get_valid_characters(player_id=player_id, provider=mongo_provider)
-    npc_hids = [hid for _, hid in npcs]
-    assert "flatworm" not in npc_hids

--- a/tests/manual/new-game.yml
+++ b/tests/manual/new-game.yml
@@ -15,15 +15,6 @@ access_settings:
 data_collection_settings:
   save_runs: false
 
-### CHARACTER SELECTION SETTINGS ###
-character_settings:
-  pc:
-    valid:
-      characters: { "where": { "hid": "human-normative" } }
-  npc:
-    valid:
-      characters: { "where": { "hid": "human-new" } }
-
 ### ADDITIONAL STOPPING CRITERIA ###
 stopping_conditions:
   runtime_seconds: [">=300"] # stop after 5 minutes
@@ -334,4 +325,3 @@ graph_config:
           - if: "{{ state['event_draft']['type'] == 'ai' }}"
             then: update
           - else: error_in_checkpoint
-

--- a/ui/src/components/chat-message.tsx
+++ b/ui/src/components/chat-message.tsx
@@ -9,7 +9,7 @@ import { cn } from '@/lib/utils'
 // muted bubble style (applied in the JSX below) is used instead.
 const EVENT_STYLES: Record<EventType, string> = {
   ai: '',
-  info: 'opacity-70',
+  info: 'opacity-85',
   error: 'bg-destructive/10 border border-destructive/30 text-destructive rounded-md px-3 py-2',
   warning: 'bg-yellow-50 border border-yellow-300 text-yellow-900 rounded-md px-3 py-2',
 }

--- a/ui/src/routes/games/$gameName.tsx
+++ b/ui/src/routes/games/$gameName.tsx
@@ -28,11 +28,6 @@ interface CharacterChoice {
   label: string
 }
 
-interface SetupCharacterChoice extends CharacterChoice {
-  name: string
-  description: string | null
-}
-
 interface GameSetupOptionsResponse {
   game: string
   allowed: boolean
@@ -43,25 +38,19 @@ interface GameSetupOptionsResponse {
   npcs: CharacterChoice[]
 }
 
+interface CharactersListResponse {
+  characters: Array<{
+    hid: string
+    short_description: string
+  }>
+}
+
 function randomPick<T>(arr: T[]): T | undefined {
   if (!arr.length) return undefined
   return arr[Math.floor(Math.random() * arr.length)]
 }
 
-function parseCharacterLabel(choice: CharacterChoice): SetupCharacterChoice {
-  const [rawName, ...rest] = choice.label.split(' - ')
-  const name = (rawName || '').trim() || choice.hid
-  const description = rest.join(' - ').trim()
-  return {
-    ...choice,
-    name,
-    description: description.length > 0 ? description : null,
-  }
-}
-
 function GameSetupPage() {
-  // useParams reads the dynamic segment from the URL; the `from` option gives TypeScript
-  // the correct type for the params object.
   const { gameName } = useParams({ from: '/games/$gameName' })
   const navigate = useNavigate()
   const [error, setError] = useState<string | null>(null)
@@ -78,13 +67,37 @@ function GameSetupPage() {
       httpClient<GameSetupOptionsResponse>(`/api/play/setup/${encodeURIComponent(gameName)}`),
   })
 
-  const pcs = useMemo(() => (setupData?.pcs ?? []).map(parseCharacterLabel), [setupData?.pcs])
-  const npcs = useMemo(() => (setupData?.npcs ?? []).map(parseCharacterLabel), [setupData?.npcs])
+  const { data: charactersData } = useQuery({
+    queryKey: ['characters-list'],
+    queryFn: () => httpClient<CharactersListResponse>('/api/characters/list'),
+  })
 
-  // useMemo recomputes only when pcs/npcs length changes, not on every render.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — re-pick only when list size changes, not on reference identity
+  const characterDescriptions = useMemo(() => {
+    const map = new Map<string, string>()
+    for (const character of charactersData?.characters ?? []) {
+      const description = character.short_description?.trim()
+      if (description) map.set(character.hid, description)
+    }
+    return map
+  }, [charactersData?.characters])
+
+  const pcs = useMemo(() => {
+    return (setupData?.pcs ?? []).map((choice) => ({
+      hid: choice.hid,
+      description: characterDescriptions.get(choice.hid) ?? null,
+    }))
+  }, [setupData?.pcs, characterDescriptions])
+
+  const npcs = useMemo(() => {
+    return (setupData?.npcs ?? []).map((choice) => ({
+      hid: choice.hid,
+      description: characterDescriptions.get(choice.hid) ?? null,
+    }))
+  }, [setupData?.npcs, characterDescriptions])
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — re-pick only when list size changes
   const defaultPc = useMemo(() => randomPick(pcs)?.hid ?? '', [pcs.length])
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — re-pick only when list size changes, not on reference identity
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — re-pick only when list size changes
   const defaultNpc = useMemo(() => randomPick(npcs)?.hid ?? '', [npcs.length])
 
   const [pcChoice, setPcChoice] = useState<string>('')
@@ -233,7 +246,7 @@ function GameSetupPage() {
                 <SelectContent>
                   {pcs.map((c) => (
                     <SelectItem key={c.hid} value={c.hid}>
-                      {c.name}
+                      {c.hid}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -254,7 +267,7 @@ function GameSetupPage() {
                 <SelectContent>
                   {npcs.map((c) => (
                     <SelectItem key={c.hid} value={c.hid}>
-                      {c.name}
+                      {c.hid}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -279,7 +292,7 @@ function GameSetupPage() {
             {isPending ? 'Starting…' : 'Play'}
           </Button>
 
-          <Button variant="ghost" className="w-full" onClick={() => navigate({ to: '/games' })}>
+          <Button variant="outline" className="w-full" onClick={() => navigate({ to: '/games' })}>
             Back to Games
           </Button>
         </CardContent>

--- a/ui/src/routes/login.tsx
+++ b/ui/src/routes/login.tsx
@@ -103,6 +103,13 @@ function LoginPage() {
                 Register here
               </Link>
             </p>
+            <p className="text-center text-xs text-muted-foreground">
+              By continuing, you agree to the{' '}
+              <Link to="/terms" className="underline underline-offset-4 hover:text-primary">
+                Terms of Use and Privacy Notice
+              </Link>
+              .
+            </p>
           </form>
         </CardContent>
       </Card>

--- a/ui/src/routes/routeTree.ts
+++ b/ui/src/routes/routeTree.ts
@@ -8,11 +8,13 @@ import { indexRoute } from './index'
 import { loginRoute } from './login'
 import { playRoute } from './play/$sessionId'
 import { signupRoute } from './signup'
+import { termsRoute } from './terms'
 
 export const routeTree = rootRoute.addChildren([
   indexRoute,
   loginRoute,
   signupRoute,
+  termsRoute,
   gamesRoute,
   gameSetupRoute,
   playRoute,

--- a/ui/src/routes/signup.tsx
+++ b/ui/src/routes/signup.tsx
@@ -92,6 +92,7 @@ function SignupPage() {
   // after they've left a field, not on initial load.
   const [touched, setTouched] = useState<Partial<Record<FormFields, boolean>>>({})
   const [consentRead, setConsentRead] = useState(false)
+  const [consentScrolledToBottom, setConsentScrolledToBottom] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   // issuedKey is set after successful registration; its presence switches the page
@@ -156,6 +157,14 @@ function SignupPage() {
     await navigator.clipboard.writeText(issuedKey)
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
+  }
+
+  function handleConsentScroll(e: React.UIEvent<HTMLDivElement>) {
+    if (consentScrolledToBottom) return
+    const { scrollTop, clientHeight, scrollHeight } = e.currentTarget
+    if (scrollTop + clientHeight >= scrollHeight - 8) {
+      setConsentScrolledToBottom(true)
+    }
   }
 
   // Swap to the key-display view once registration succeeds.
@@ -275,13 +284,100 @@ function SignupPage() {
               </Label>
             </div>
 
-            <div className="flex items-center gap-2">
+            <div className="space-y-2">
+              <Label htmlFor="consent_text">Consent Form</Label>
+              <div
+                id="consent_text"
+                onScroll={handleConsentScroll}
+                className="h-48 overflow-y-auto rounded-md border bg-muted/30 p-3 text-sm leading-6"
+              >
+                <h4 className="font-semibold">Terms of Use</h4>
+                <p className="mt-2">
+                  This platform hosts research studies conducted by independent researchers. By
+                  accessing or participating in studies on this site, you agree to use the platform
+                  in a responsible manner.
+                </p>
+                <p className="mt-2">
+                  <span className="font-medium">Acceptable Use:</span> You may not attempt to
+                  interfere with the operation of the platform or any studies hosted on it. This
+                  includes attempting to access data that does not belong to you, using automated
+                  scripts or bots to complete studies, attempting to reverse engineer study
+                  materials, or otherwise disrupting the system.
+                </p>
+                <p className="mt-2">
+                  <span className="font-medium">Independent Researchers:</span> Studies hosted on
+                  this platform are created and managed by independent researchers. These
+                  researchers are responsible for the design of their studies, obtaining appropriate
+                  ethical approval (such as IRB approval), and providing informed consent
+                  information to participants.
+                </p>
+                <p className="mt-2">
+                  <span className="font-medium">Research Participation:</span> Participation in any
+                  study is voluntary. Each study will provide its own informed consent document
+                  describing the purpose of the research, procedures, risks, benefits, and data
+                  handling practices.
+                </p>
+                <p className="mt-2">
+                  <span className="font-medium">Platform Availability:</span> The platform is
+                  provided for research purposes and may occasionally be unavailable due to
+                  maintenance, updates, or technical issues.
+                </p>
+
+                <h4 className="mt-4 font-semibold">Privacy Notice</h4>
+                <p className="mt-2">
+                  This platform hosts research studies conducted by independent researchers.
+                  Individual studies may collect research data as described in their informed
+                  consent documents.
+                </p>
+                <p className="mt-2">
+                  <span className="font-medium">Platform Data:</span> To operate the platform and
+                  support research integrity, the system may collect limited technical information
+                  such as timestamps, browser or device information, IP address, and interaction
+                  logs related to study participation.
+                </p>
+                <p className="mt-2">
+                  <span className="font-medium">Research Data:</span> Data collected within a study
+                  is determined by the researcher conducting that study and will be described in the
+                  study&apos;s informed consent document.
+                </p>
+                <p className="mt-2">
+                  <span className="font-medium">Use of Information:</span> Platform data is used to
+                  operate the system, troubleshoot technical issues, and help ensure the quality and
+                  integrity of research data.
+                </p>
+                <p className="mt-2">
+                  <span className="font-medium">Contact:</span> Questions about a specific study
+                  should be directed to the researcher listed in that study&apos;s consent form.
+                </p>
+              </div>
+              {!consentScrolledToBottom && (
+                <p className="text-xs text-muted-foreground">
+                  Scroll to the bottom of the consent form to enable acknowledgment.
+                </p>
+              )}
+            </div>
+
+            <div
+              className={`flex items-center gap-2 transition-opacity ${
+                consentScrolledToBottom ? 'opacity-100' : 'opacity-50'
+              }`}
+            >
               <Checkbox
                 id="consent_read"
                 checked={consentRead}
-                onCheckedChange={(v) => setConsentRead(Boolean(v))}
+                onCheckedChange={(v) => {
+                  if (consentScrolledToBottom) {
+                    setConsentRead(Boolean(v))
+                  }
+                }}
+                disabled={!consentScrolledToBottom}
               />
-              <Label htmlFor="consent_read" className="font-normal">
+              <Label
+                htmlFor="consent_read"
+                className={`font-normal ${
+                  consentScrolledToBottom ? '' : 'cursor-not-allowed text-muted-foreground'
+                }`}
+              >
                 I have read and understood the consent form.
               </Label>
             </div>

--- a/ui/src/routes/terms.tsx
+++ b/ui/src/routes/terms.tsx
@@ -1,0 +1,116 @@
+import { createRoute } from '@tanstack/react-router'
+import { ThemeToggle } from '@/components/theme-toggle'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { rootRoute } from './__root'
+
+function TermsPage() {
+  return (
+    <div className="min-h-screen bg-background p-4 md:p-6">
+      <div className="fixed top-3 right-3">
+        <ThemeToggle />
+      </div>
+      <div className="mx-auto flex w-full max-w-3xl items-center justify-center py-10">
+        <Card className="w-full">
+          <CardHeader>
+            <CardTitle>Terms of Use</CardTitle>
+            <CardDescription>Rules and privacy details for platform participation.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-6 text-sm leading-6 text-foreground">
+            <section className="space-y-3">
+              <p>
+                This platform hosts research studies conducted by independent researchers. By
+                accessing or participating in studies on this site, you agree to use the platform in
+                a responsible manner.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="text-base font-semibold">Acceptable Use</h2>
+              <p>
+                You may not attempt to interfere with the operation of the platform or any studies
+                hosted on it. This includes attempting to access data that does not belong to you,
+                using automated scripts or bots to complete studies, attempting to reverse engineer
+                study materials, or otherwise disrupting the system.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="text-base font-semibold">Independent Researchers</h2>
+              <p>
+                Studies hosted on this platform are created and managed by independent researchers.
+                These researchers are responsible for the design of their studies, obtaining
+                appropriate ethical approval (such as IRB approval), and providing informed consent
+                information to participants.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="text-base font-semibold">Research Participation</h2>
+              <p>
+                Participation in any study is voluntary. Each study will provide its own informed
+                consent document describing the purpose of the research, procedures, risks,
+                benefits, and data handling practices.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="text-base font-semibold">Platform Availability</h2>
+              <p>
+                The platform is provided for research purposes and may occasionally be unavailable
+                due to maintenance, updates, or technical issues.
+              </p>
+            </section>
+
+            <section className="space-y-3 border-t pt-6">
+              <h2 className="text-lg font-semibold">Privacy Notice</h2>
+              <p>
+                This platform hosts research studies conducted by independent researchers.
+                Individual studies may collect research data as described in their informed consent
+                documents.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h3 className="text-base font-semibold">Platform Data</h3>
+              <p>
+                To operate the platform and support research integrity, the system may collect
+                limited technical information such as timestamps, browser or device information, IP
+                address, and interaction logs related to study participation.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h3 className="text-base font-semibold">Research Data</h3>
+              <p>
+                Data collected within a study is determined by the researcher conducting that study
+                and will be described in the study&apos;s informed consent document.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h3 className="text-base font-semibold">Use of Information</h3>
+              <p>
+                Platform data is used to operate the system, troubleshoot technical issues, and help
+                ensure the quality and integrity of research data.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h3 className="text-base font-semibold">Contact</h3>
+              <p>
+                Questions about a specific study should be directed to the researcher listed in that
+                study&apos;s consent form.
+              </p>
+            </section>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}
+
+export const termsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/terms',
+  component: TermsPage,
+})


### PR DESCRIPTION

This change removes the current character selection/filtering layer from runtime
so all games expose the full character pool for both PC and NPC selection,
while keeping setup/session flows intact. It also updates setup/auth UI behavior
to match the simplified server contract and improves readability/usability.

### Key changes:
  - Remove `character_settings` / `character_selection` models and filtering logic
    from `GameConfig`
  - Simplify `get_valid_characters(...)` to return all characters for both PC/NPC
    as `(hid, hid)` pairs
  - Simplify DAL character listing interface to `list_characters()` with no filter args
  - Update Mongo provider to return all characters without descriptor/exclude filters
  - Remove character selection/display blocks from game YAML configs and manual fixture
  - Update `tests/core/test_game_config.py` to assert unfiltered global pools
  - Update game setup UI to render canonical HIDs and source descriptions from
    `/api/characters/list`
  - Keep PC/NPC selectors enabled and make “Back to Games” a visible outline button
  - Improve info message contrast in chat bubbles
  - Add Terms/Privacy route and link from login; gate signup consent acknowledgment
    until the consent text has been scrolled to the bottom
    
 ###  Why:
  - Will be rewriting character selection as apart of assignment strategy.