### PR TITLE
feat: rename prediction commands and slim hosted deploy defaults

### DIFF
--- a/.devcontainer/zshrc
+++ b/.devcontainer/zshrc
@@ -21,6 +21,9 @@ antigen bundle sindresorhus/pure@main
 # Syntax highlighting
 antigen bundle zsh-users/zsh-syntax-highlighting@master
 
+# Auto-suggest lookup https://github.com/zsh-users/zsh-autosuggestions
+antigen bundle zsh-users/zsh-autosuggestions
+
 # Apply antigen settings
 antigen apply
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -320,12 +320,12 @@ dcs remote deploy \
   --admin-key dcs-ak-YOUR_KEY_HERE \
   --config /experiments/usability-ca.yml \
   --mongo-seed-path database_seeds/prod \
-  --regions lax sjc sea
+  --regions iad # cheapest region
 
 # deploy free play
 dcs remote deploy \
   --admin-key dcs-ak-YOUR_KEY_HERE \
   --free-play \
   --mongo-seed-path database_seeds/prod \
-  --regions lax sjc sea
+  --regions iad # cheapest region
 ```

--- a/dcs_simulation_engine/api/infer_intent_evaluation.py
+++ b/dcs_simulation_engine/api/infer_intent_evaluation.py
@@ -26,18 +26,18 @@ class InferIntentEvaluationUnavailableError(ValueError):
 
 
 def extract_infer_intent_scoring_inputs(events: list[SessionEventRecord]) -> tuple[str, str]:
-    """Rebuild the transcript and saved player guess from persisted session events."""
+    """Rebuild the transcript and saved player intent prediction from persisted session events."""
     transcript_lines: list[str] = []
-    found_guess_command = False
-    guess = ""
+    found_prediction_command = False
+    prediction = ""
 
     for event in sorted(events, key=lambda item: item.seq):
         if event.data.get(MongoColumns.VISIBLE_TO_USER) is False:
             continue
 
-        if not found_guess_command:
-            if _is_guess_command(event):
-                found_guess_command = True
+        if not found_prediction_command:
+            if _is_prediction_command(event):
+                found_prediction_command = True
                 continue
 
             if event.direction == "inbound" and event.event_source == "user" and event.event_type == "message":
@@ -51,19 +51,17 @@ def extract_infer_intent_scoring_inputs(events: list[SessionEventRecord]) -> tup
             continue
 
         if event.direction == "inbound" and event.event_source == "user" and event.event_type == "message":
-            guess = event.content.strip()
+            prediction = event.content.strip()
             break
 
-    if not found_guess_command:
+    if not found_prediction_command:
+        raise InferIntentEvaluationUnavailableError("Infer Intent evaluation is unavailable because no prediction was saved.")
+    if not prediction:
         raise InferIntentEvaluationUnavailableError(
-            "Infer Intent evaluation is unavailable because no guess was saved."
-        )
-    if not guess:
-        raise InferIntentEvaluationUnavailableError(
-            "Infer Intent evaluation is unavailable because the saved guess could not be found."
+            "Infer Intent evaluation is unavailable because the saved prediction could not be found."
         )
 
-    return ("\n".join(transcript_lines), guess)
+    return ("\n".join(transcript_lines), prediction)
 
 
 async def generate_or_get_infer_intent_evaluation(
@@ -89,9 +87,9 @@ async def generate_or_get_infer_intent_evaluation(
             evaluation=InferIntentEvaluation.model_validate_json(cached_event.content),
         )
 
-    transcript, guess = extract_infer_intent_scoring_inputs(events)
+    transcript, prediction = extract_infer_intent_scoring_inputs(events)
     npc = await _load_session_npc(provider=provider, session=session)
-    scorer_result = await ScorerClient(npc=npc).score(transcript, guess)
+    scorer_result = await ScorerClient(npc=npc).score(transcript, prediction)
     evaluation = InferIntentEvaluation.model_validate(scorer_result.evaluation)
 
     append_event = getattr(provider, "append_session_event", None)
@@ -129,32 +127,26 @@ def _find_cached_evaluation_event(events: list[SessionEventRecord]) -> SessionEv
     return None
 
 
-def _is_guess_command(event: SessionEventRecord) -> bool:
+def _is_prediction_command(event: SessionEventRecord) -> bool:
     return (
         event.direction == "inbound"
         and event.event_source == "user"
         and event.event_type == "command"
-        and str(event.data.get(MongoColumns.COMMAND_NAME, "")).lower() == "guess"
+        and str(event.data.get(MongoColumns.COMMAND_NAME, "")).lower() == "predict-intent"
     )
 
 
 def _validate_infer_intent_session(session: SessionRecord) -> None:
     if session.game_name != INFER_INTENT_GAME_NAME:
-        raise InferIntentEvaluationUnavailableError(
-            "Infer Intent evaluation is only available for completed Infer Intent sessions."
-        )
+        raise InferIntentEvaluationUnavailableError("Infer Intent evaluation is only available for completed Infer Intent sessions.")
 
     termination_reason = str(session.data.get(MongoColumns.TERMINATION_REASON, "")).strip().lower()
     if termination_reason != "game_completed":
-        raise InferIntentEvaluationUnavailableError(
-            "Infer Intent evaluation is not available until the game is completed."
-        )
+        raise InferIntentEvaluationUnavailableError("Infer Intent evaluation is not available until the game is completed.")
 
 
 async def _load_session_npc(*, provider: Any, session: SessionRecord) -> CharacterRecord:
     npc_hid = str(session.data.get(MongoColumns.NPC_HID, "")).strip()
     if not npc_hid:
-        raise InferIntentEvaluationUnavailableError(
-            "Infer Intent evaluation is unavailable because the session does not have a saved NPC."
-        )
+        raise InferIntentEvaluationUnavailableError("Infer Intent evaluation is unavailable because the session does not have a saved NPC.")
     return await maybe_await(provider.get_character(hid=npc_hid))

--- a/dcs_simulation_engine/api/routers/catalog.py
+++ b/dcs_simulation_engine/api/routers/catalog.py
@@ -19,10 +19,7 @@ router = APIRouter(prefix="/api", tags=["catalog"])
 @router.get("/games/list", response_model=GamesListResponse)
 def list_games_endpoint() -> GamesListResponse:
     """List available games."""
-    games = [
-        GameSummary(name=name, author=author, description=description)
-        for name, author, _path, _version, description in list_games()
-    ]
+    games = [GameSummary(name=name, author=author, description=description) for name, author, _path, _version, description in list_games()]
     return GamesListResponse(games=games)
 
 

--- a/dcs_simulation_engine/api/routers/play.py
+++ b/dcs_simulation_engine/api/routers/play.py
@@ -179,9 +179,7 @@ async def setup_options(game_name: str, request: Request) -> GameSetupOptionsRes
 
     get_valid = getattr(game_config, "get_valid_characters_async", None)
     if get_valid is None:
-        valid_pcs, valid_npcs = await maybe_await(
-            game_config.get_valid_characters(player_id=player_id, provider=provider)
-        )
+        valid_pcs, valid_npcs = await maybe_await(game_config.get_valid_characters(player_id=player_id, provider=provider))
     else:
         valid_pcs, valid_npcs = await maybe_await(get_valid(player_id=player_id, provider=provider))
     pcs = [CharacterChoice(hid=hid, label=label) for label, hid in valid_pcs]

--- a/dcs_simulation_engine/cli/commands/remote.py
+++ b/dcs_simulation_engine/cli/commands/remote.py
@@ -211,6 +211,7 @@ def deploy(
     echo(ctx, f"Deployed apps: {', '.join(result.deployed_apps)}")
     echo(ctx, f"API: {result.api_url}")
     echo(ctx, f"UI: {result.ui_url}")
+    echo(ctx, f"Open the UI in your browser: {result.ui_url}")
     echo(ctx, f"Apps: api={result.api_app} ui={result.ui_app} db={result.db_app}")
     if result.admin_api_key:
         echo(ctx, f"Admin access key: {result.admin_api_key}", style="error")

--- a/dcs_simulation_engine/core/assignment_strategies/random_unique.py
+++ b/dcs_simulation_engine/core/assignment_strategies/random_unique.py
@@ -31,9 +31,7 @@ class RandomUniqueAssignmentStrategy:
         if max_assignments is not None and max_assignments <= 0:
             raise ValueError("random_unique requires max_assignments_per_player to be positive")
         if max_assignments is not None and max_assignments > len(config.games):
-            raise ValueError(
-                "random_unique cannot assign more games per player than are listed in assignment_strategy.games"
-            )
+            raise ValueError("random_unique cannot assign more games per player than are listed in assignment_strategy.games")
 
     def max_assignments_per_player(self, *, config: "ExperimentConfig") -> int:
         """Return the configured max assignments, capped by the game list."""
@@ -60,9 +58,7 @@ class RandomUniqueAssignmentStrategy:
         return {
             "total": quota * len(config.games),
             "completed": completed_total,
-            "is_complete": all(
-                len(counted_players_by_game.get(game_name, set())) >= quota for game_name in config.games
-            ),
+            "is_complete": all(len(counted_players_by_game.get(game_name, set())) >= quota for game_name in config.games),
         }
 
     async def compute_status_async(self, *, provider: Any, config: "ExperimentConfig") -> dict[str, Any]:
@@ -108,15 +104,11 @@ class RandomUniqueAssignmentStrategy:
         player: "PlayerRecord",
     ) -> "AssignmentRecord | None":
         """Reuse active work or create a new random unique assignment for a player."""
-        active_assignment = await maybe_await(
-            provider.get_active_assignment(experiment_name=config.name, player_id=player.id)
-        )
+        active_assignment = await maybe_await(provider.get_active_assignment(experiment_name=config.name, player_id=player.id))
         if active_assignment is not None:
             return active_assignment
 
-        player_assignments = await maybe_await(
-            provider.list_assignments(experiment_name=config.name, player_id=player.id)
-        )
+        player_assignments = await maybe_await(provider.list_assignments(experiment_name=config.name, player_id=player.id))
         completed_count = sum(1 for item in player_assignments if item.status == "completed")
         if completed_count >= self.max_assignments_per_player(config=config):
             return None
@@ -144,9 +136,7 @@ class RandomUniqueAssignmentStrategy:
             game_config = SessionManager.get_game_config_cached(game_name)
             get_valid = getattr(game_config, "get_valid_characters_async", None)
             if get_valid is None:
-                valid_pcs, _ = await maybe_await(
-                    game_config.get_valid_characters(player_id=player.id, provider=provider)
-                )
+                valid_pcs, _ = await maybe_await(game_config.get_valid_characters(player_id=player.id, provider=provider))
             else:
                 valid_pcs, _ = await maybe_await(get_valid(player_id=player.id, provider=provider))
 

--- a/dcs_simulation_engine/core/experiment_manager.py
+++ b/dcs_simulation_engine/core/experiment_manager.py
@@ -127,18 +127,13 @@ class ExperimentManager:
     ) -> dict[str, Any]:
         """Return the assignment state visible to one authenticated player."""
         config = cls.get_experiment_config_cached(experiment_name)
-        active_assignment = await maybe_await(
-            provider.get_active_assignment(experiment_name=experiment_name, player_id=player_id)
-        )
-        player_assignments = await maybe_await(
-            provider.list_assignments(experiment_name=experiment_name, player_id=player_id)
-        )
+        active_assignment = await maybe_await(provider.get_active_assignment(experiment_name=experiment_name, player_id=player_id))
+        player_assignments = await maybe_await(provider.list_assignments(experiment_name=experiment_name, player_id=player_id))
         completed_assignments = [item for item in player_assignments if item.status == "completed"]
         before_form_names = {form.name for form in config.forms_for_phase(before_or_after="before")}
         after_form_names = {form.name for form in config.forms_for_phase(before_or_after="after")}
         has_submitted_before_forms = not before_form_names or any(
-            before_form_names.issubset(set(item.data.get(MongoColumns.FORM_RESPONSES, {}).keys()))
-            for item in player_assignments
+            before_form_names.issubset(set(item.data.get(MongoColumns.FORM_RESPONSES, {}).keys())) for item in player_assignments
         )
         pending_post_play = next(
             (
@@ -151,12 +146,7 @@ class ExperimentManager:
         strategy = cls._strategy_for(config=config)
         has_finished_experiment = len(completed_assignments) >= strategy.max_assignments_per_player(config=config)
 
-        if (
-            active_assignment is None
-            and pending_post_play is None
-            and has_submitted_before_forms
-            and not has_finished_experiment
-        ):
+        if active_assignment is None and pending_post_play is None and has_submitted_before_forms and not has_finished_experiment:
             player_record = await maybe_await(provider.get_player(player_id=player_id))
             if player_record is not None:
                 active_assignment = await cls.get_or_create_assignment_async(
@@ -220,9 +210,7 @@ class ExperimentManager:
         """Return the active assignment for a player or create one on demand."""
         config = cls.get_experiment_config_cached(experiment_name)
         strategy = cls._strategy_for(config=config)
-        return await maybe_await(
-            strategy.get_or_create_assignment_async(provider=provider, config=config, player=player)
-        )
+        return await maybe_await(strategy.get_or_create_assignment_async(provider=provider, config=config, player=player))
 
     @classmethod
     async def start_assignment_session_async(
@@ -235,9 +223,7 @@ class ExperimentManager:
         source: str = "experiment",
     ) -> tuple["SessionEntry", AssignmentRecord]:
         """Start a gameplay session for the current assignment."""
-        assignment = await maybe_await(
-            provider.get_active_assignment(experiment_name=experiment_name, player_id=player.id)
-        )
+        assignment = await maybe_await(provider.get_active_assignment(experiment_name=experiment_name, player_id=player.id))
         if assignment is None:
             raise ValueError("No active assignment is available for this player.")
         if assignment.status == "in_progress":

--- a/dcs_simulation_engine/core/session_event_recorder.py
+++ b/dcs_simulation_engine/core/session_event_recorder.py
@@ -26,8 +26,7 @@ _ALLOWED_EVENT_CLASSIFICATIONS = {
 def _validate_event_classification(*, direction: str, event_source: str, event_type: str) -> None:
     if (direction, event_source, event_type) not in _ALLOWED_EVENT_CLASSIFICATIONS:
         raise ValueError(
-            f"Invalid session event classification: direction={direction!r}, "
-            f"event_source={event_source!r}, event_type={event_type!r}"
+            f"Invalid session event classification: direction={direction!r}, event_source={event_source!r}, event_type={event_type!r}"
         )
 
 

--- a/dcs_simulation_engine/core/session_manager.py
+++ b/dcs_simulation_engine/core/session_manager.py
@@ -113,9 +113,7 @@ class SessionManager:
 
         get_valid = getattr(game_config, "get_valid_characters_async", None)
         if get_valid is None:
-            valid_pcs, valid_npcs = await maybe_await(
-                game_config.get_valid_characters(player_id=player_id, provider=provider)
-            )
+            valid_pcs, valid_npcs = await maybe_await(game_config.get_valid_characters(player_id=player_id, provider=provider))
         else:
             valid_pcs, valid_npcs = await maybe_await(get_valid(player_id=player_id, provider=provider))
         valid_pc_hids = [hid for _, hid in valid_pcs]
@@ -387,12 +385,8 @@ class SessionManager:
             self._events.append(payload)
             if self._recorder_open and self._recorder is not None:
                 persisted_event_type, persisted_event_source = self._classify_persisted_outbound_event(event)
-                outbound_command_name = (
-                    parsed_command[0] if event.command_response and parsed_command is not None else None
-                )
-                outbound_command_args = (
-                    parsed_command[1] if event.command_response and parsed_command is not None else None
-                )
+                outbound_command_name = parsed_command[0] if event.command_response and parsed_command is not None else None
+                outbound_command_args = parsed_command[1] if event.command_response and parsed_command is not None else None
                 recorded = await self._recorder.record_outbound(
                     event_type=persisted_event_type,
                     event_source=persisted_event_source,

--- a/dcs_simulation_engine/dal/mongo/async_provider.py
+++ b/dcs_simulation_engine/dal/mongo/async_provider.py
@@ -617,9 +617,7 @@ class AsyncMongoProvider:
 
     async def get_assignment(self, *, assignment_id: str) -> AssignmentRecord | None:
         """Return one assignment row by assignment_id."""
-        doc = await maybe_await(
-            self._db[MongoColumns.ASSIGNMENTS].find_one({MongoColumns.ASSIGNMENT_ID: assignment_id})
-        )
+        doc = await maybe_await(self._db[MongoColumns.ASSIGNMENTS].find_one({MongoColumns.ASSIGNMENT_ID: assignment_id}))
         if not doc:
             return None
         return _to_assignment_record(doc)

--- a/dcs_simulation_engine/dal/mongo/util.py
+++ b/dcs_simulation_engine/dal/mongo/util.py
@@ -49,18 +49,14 @@ def ensure_default_indexes(db: Database[Any]) -> None:
     db[MongoColumns.PLAYERS].create_index("access_key", unique=True, sparse=True)
     db[MongoColumns.PII].create_index(MongoColumns.PLAYER_ID, unique=True)
     db[MongoColumns.SESSIONS].create_index(MongoColumns.SESSION_ID, unique=True)
-    db[MongoColumns.SESSIONS].create_index(
-        [(MongoColumns.PLAYER_ID, ASCENDING), (MongoColumns.SESSION_STARTED_AT, DESCENDING)]
-    )
+    db[MongoColumns.SESSIONS].create_index([(MongoColumns.PLAYER_ID, ASCENDING), (MongoColumns.SESSION_STARTED_AT, DESCENDING)])
     db[MongoColumns.SESSIONS].create_index([(MongoColumns.STATUS, ASCENDING), (MongoColumns.UPDATED_AT, DESCENDING)])
     db[MongoColumns.SESSION_EVENTS].create_index(
         [(MongoColumns.SESSION_ID, ASCENDING), (MongoColumns.SEQ, ASCENDING)],
         unique=True,
     )
     db[MongoColumns.SESSION_EVENTS].create_index(MongoColumns.EVENT_ID, unique=True)
-    db[MongoColumns.SESSION_EVENTS].create_index(
-        [(MongoColumns.SESSION_ID, ASCENDING), (MongoColumns.EVENT_TS, ASCENDING)]
-    )
+    db[MongoColumns.SESSION_EVENTS].create_index([(MongoColumns.SESSION_ID, ASCENDING), (MongoColumns.EVENT_TS, ASCENDING)])
     db[MongoColumns.EXPERIMENTS].create_index(MongoColumns.NAME, unique=True)
     db[MongoColumns.ASSIGNMENTS].create_index(MongoColumns.ASSIGNMENT_ID, unique=True)
     db[MongoColumns.ASSIGNMENTS].create_index(
@@ -97,20 +93,14 @@ async def ensure_default_indexes_async(db: AsyncDatabase[Any]) -> None:
     await db[MongoColumns.PLAYERS].create_index("access_key", unique=True, sparse=True)
     await db[MongoColumns.PII].create_index(MongoColumns.PLAYER_ID, unique=True)
     await db[MongoColumns.SESSIONS].create_index(MongoColumns.SESSION_ID, unique=True)
-    await db[MongoColumns.SESSIONS].create_index(
-        [(MongoColumns.PLAYER_ID, ASCENDING), (MongoColumns.SESSION_STARTED_AT, DESCENDING)]
-    )
-    await db[MongoColumns.SESSIONS].create_index(
-        [(MongoColumns.STATUS, ASCENDING), (MongoColumns.UPDATED_AT, DESCENDING)]
-    )
+    await db[MongoColumns.SESSIONS].create_index([(MongoColumns.PLAYER_ID, ASCENDING), (MongoColumns.SESSION_STARTED_AT, DESCENDING)])
+    await db[MongoColumns.SESSIONS].create_index([(MongoColumns.STATUS, ASCENDING), (MongoColumns.UPDATED_AT, DESCENDING)])
     await db[MongoColumns.SESSION_EVENTS].create_index(
         [(MongoColumns.SESSION_ID, ASCENDING), (MongoColumns.SEQ, ASCENDING)],
         unique=True,
     )
     await db[MongoColumns.SESSION_EVENTS].create_index(MongoColumns.EVENT_ID, unique=True)
-    await db[MongoColumns.SESSION_EVENTS].create_index(
-        [(MongoColumns.SESSION_ID, ASCENDING), (MongoColumns.EVENT_TS, ASCENDING)]
-    )
+    await db[MongoColumns.SESSION_EVENTS].create_index([(MongoColumns.SESSION_ID, ASCENDING), (MongoColumns.EVENT_TS, ASCENDING)])
     await db[MongoColumns.EXPERIMENTS].create_index(MongoColumns.NAME, unique=True)
     await db[MongoColumns.ASSIGNMENTS].create_index(MongoColumns.ASSIGNMENT_ID, unique=True)
     await db[MongoColumns.ASSIGNMENTS].create_index(
@@ -226,9 +216,7 @@ def dump_all_collections_to_json(db: Database[Any], path: str | Path) -> Path:
             finally:
                 cursor.close()
             f.write("\n]\n")
-        _write_collection_indexes(
-            root, collection_name=collection_name, index_info=db[collection_name].index_information()
-        )
+        _write_collection_indexes(root, collection_name=collection_name, index_info=db[collection_name].index_information())
 
     _write_dump_manifest(root, db_name=db.name, collections=collection_names)
 

--- a/dcs_simulation_engine/deployments/templates/api.fly.toml.j2
+++ b/dcs_simulation_engine/deployments/templates/api.fly.toml.j2
@@ -17,4 +17,4 @@ app = "{{ app_name }}"
 [[vm]]
   cpu_kind = "shared"
   cpus = 1
-  memory = "1gb"
+  memory = "512mb"

--- a/dcs_simulation_engine/deployments/templates/db.fly.toml.j2
+++ b/dcs_simulation_engine/deployments/templates/db.fly.toml.j2
@@ -18,4 +18,4 @@ app = "{{ app_name }}"
 [[vm]]
   cpu_kind = "shared"
   cpus = 1
-  memory = "1gb"
+  memory = "512mb"

--- a/dcs_simulation_engine/games/ai_client.py
+++ b/dcs_simulation_engine/games/ai_client.py
@@ -39,8 +39,7 @@ def validate_openrouter_configuration() -> None:
     key = os.getenv("OPENROUTER_API_KEY", "").strip()
     if not key:
         raise RuntimeError(
-            "OPENROUTER_API_KEY is required to start the server. "
-            "Set it in the environment, or use --fake-ai-response for local mock mode."
+            "OPENROUTER_API_KEY is required to start the server. Set it in the environment, or use --fake-ai-response for local mock mode."
         )
 
 

--- a/dcs_simulation_engine/games/const.py
+++ b/dcs_simulation_engine/games/const.py
@@ -49,49 +49,48 @@ class Foresight:
     """String constants for the new-style Foresight game (Python format strings, not Jinja2)."""
 
     ENTER_CONTENT = """\
-*Welcome, in this game you take on the role of a character whose aim is to understand the other \
-character well enough to predict their actions.*
+*Welcome, in this game you take on the role of a character whose aim is to understand the other character well enough to predict their actions.*
 
-Engage with the other character using your abilities. When you feel ready, include a prediction \
-alongside your action — for example: "I wave my hand and predict they will wave back."
+Engage with the other character using your abilities. When you want to record a prediction, type `/predict-next` to say what you think the simulator character will do next.
 
 - You are playing as: {pc_hid} ({pc_short_description})
 
-Type `/help` for instructions. Type `/complete` when you are done to submit your notes. You can include notes in the same message or send them on the next turn.\
+Type `/help` for instructions. Type `/predict-next` whenever you want to log another prediction.\
 """
 
     HELP_CONTENT = """\
 ##### Objective
-Interact with the other character and learn to predict their responses.
+Interact with the other character and learn to predict their next action.
 
-##### Actions and Predictions
-Describe an action your character takes (and optionally include a prediction about the other character's response).
+##### Actions
+Describe an action your character takes.
 - Eg. "I look around the room and walk to the door."
-- Eg. "I look around the room and walk to the door, and I predict they will follow me."
+
+##### Predictions
+Use `/predict-next` whenever you want to record what you think the simulator character will do next.
+- Eg. `/predict-next I think they will follow me to the door.`
 
 ##### Commands
 Type `/help` to see this message again.
-Type `/complete` to end the game and submit your prediction notes. You can also use `/complete <notes>` to submit them immediately.
-Type `/exit` to leave without submitting notes.\
+Type `/predict-next` to record a prediction. You can also use `/predict-next <prediction>` to submit it immediately.
+Type `/exit` to leave the game.\
 """
 
-    COMPLETE_QUESTION = """\
-Thanks for playing! Before you go, please share any notes about your predictions:
+    PREDICT_NEXT_QUESTION = """\
+What do you predict the simulator character will do next?
 
-Were any predictions particularly interesting or challenging? Describe in a few sentences \
-(or type 'none' to skip).\
+Describe your prediction in a sentence or two.\
 """
+
+    PREDICT_NEXT_CONFIRMATION = "Prediction noted. Continue interacting, or use `/predict-next` again anytime."
 
     ADDITIONAL_VALIDATOR_RULES = """\
-- ALLOW PREDICTIONS: The user's input IS ALLOWED to include a prediction about what the \
-other character's response will be. For example, "I wave my hand and predict they will wave back."\
+- ALLOW PREDICTIONS: The user's input IS ALLOWED to include a prediction about what the other character's response will be. For example, "I wave my hand and predict they will wave back."\
 """
 
     ADDITIONAL_UPDATER_RULES = """\
 - IGNORE PREDICTIONS:
-The user's input MAY include a prediction about what the simulator character's response will be. \
-IGNORE ANY PREDICTIONS ENTIRELY. DO NOT ADJUDICATE THEM OR RESPOND TO THEM IN ANY WAY. \
-ONLY RESPOND TO THE USER'S ACTION.\
+The user's input MAY include a prediction about what the simulator character's response will be. IGNORE ANY PREDICTIONS ENTIRELY. DO NOT ADJUDICATE THEM OR RESPOND TO THEM IN ANY WAY. ONLY RESPOND TO THE USER'S ACTION.\
 """
 
 
@@ -101,18 +100,16 @@ class InferIntent:
     ENTER_CONTENT = """\
 *Welcome, in this game you interact with an unknown character and try to infer their goal or intention.*
 
-Engage with the other character using your abilities. When you think you understand their goal, \
-type `/guess` to submit your inference.
+Engage with the other character using your abilities. When you think you understand their goal, type `/predict-intent` to submit your inference and end the game.
 
 - You are playing as: {pc_hid} ({pc_short_description})
 
-Type `/help` for instructions. Type `/abilities` to see your character's abilities.\
+Type `/help` for instructions. Type `/predict-intent` when you are ready to answer.\
 """
 
     HELP_CONTENT = """\
 ##### Objective
-Interact with the other character and figure out their goal or intention. \
-When you feel confident, type `/guess` to submit your inference.
+Interact with the other character and figure out their goal or intention. When you feel confident, type `/predict-intent` to submit your inference and end the game.
 
 ##### Rules
 Describe an action that makes sense in the context of the scene and uses your character's abilities.
@@ -120,8 +117,7 @@ Describe an action that makes sense in the context of the scene and uses your ch
 
 ##### Commands
 Type `/help` to see this message again.
-Type `/abilities` to see your character's abilities.
-Type `/guess` when you think you understand the NPC's goal to end the interaction and submit your inference.
+Type `/predict-intent` when you think you understand the character's intent to end the interaction and submit your inference.
 Type `/exit` to leave the game without submitting an inference.\
 """
 
@@ -131,15 +127,13 @@ Type `/exit` to leave the game without submitting an inference.\
 """
 
     GOAL_INFERENCE_QUESTION = """\
-What do you think the NPC's goal or intention was during this interaction? \
-Please describe in a few sentences.\
+What do you think the character's goal or intention was during this interaction? Please describe in a few sentences.\
 """
 
     OTHER_FEEDBACK_QUESTION = "Do you have any other feedback about this experience?"
 
     ADDITIONAL_UPDATER_RULES = """\
-- Goal Aligned Response: The simulator character's response should be in-line with a specific \
-goal or intention that s/he/it/they are trying to communicate with the user character.\
+- Goal Aligned Response: The simulator character's response should be in-line with a specific goal or intention that s/he/it/they are trying to communicate with the user character.\
 """
 
 
@@ -149,17 +143,17 @@ class GoalHorizon:
     ENTER_CONTENT = """\
 *Welcome, in this game you interact with an unknown character across multiple scenes to understand the bounds and structure of their goals.*
 
-Engage with the other character using your abilities. There is no predefined objective — explore freely.
+Engage with the other character using your abilities. When you think you understand the character's limits, type `/predict-capabilities` to submit your answer and end the game.
 
 - You are playing as: {pc_hid} ({pc_short_description})
 - The simulator is playing as: {npc_hid} ({npc_short_description})
 
-Type `/help` for instructions. Type `/abilities` to see your character's abilities.\
+Type `/help` for instructions. Type `/predict-capabilities` when you are ready to answer.\
 """
 
     HELP_CONTENT = """\
 ##### Objective
-Interact with the other character across multiple scenes to understand the scope and structure of their goals.
+Interact with the other character across multiple scenes to understand the scope and limits of their goals and capabilities.
 
 ##### Rules
 Describe an action that makes sense in the context of the scene and uses your character's abilities.
@@ -167,7 +161,7 @@ Describe an action that makes sense in the context of the scene and uses your ch
 
 ##### Commands
 Type `/help` to see this message again.
-Type `/abilities` to see your character's abilities.
+Type `/predict-capabilities` when you think you understand the character's limits. This ends the game.
 Type `/exit` to leave the game.\
 """
 
@@ -183,4 +177,10 @@ Type `/exit` to leave the game.\
 
 ## Simulator Character Abilities
 {npc_abilities}\
+"""
+
+    CAPABILITY_PREDICTION_QUESTION = """\
+What do you think this character's limits or capabilities are?
+
+Describe the bounds you inferred in a few sentences.\
 """

--- a/dcs_simulation_engine/games/foresight.py
+++ b/dcs_simulation_engine/games/foresight.py
@@ -23,11 +23,11 @@ class Command(StrEnum):
     """Game-level slash commands recognized by ForesightGame."""
 
     HELP = "help"
-    COMPLETE = "complete"
+    PREDICT_NEXT = "predict-next"
 
 
 class ForesightGame(Game):
-    """Foresight game: player interacts with NPC and makes predictions about their responses."""
+    """Foresight game: player interacts with NPC and makes repeatable predictions."""
 
     DEFAULT_RETRY_BUDGET = 10
     DEFAULT_MAX_INPUT_LENGTH = 350
@@ -52,9 +52,8 @@ class ForesightGame(Game):
         self._exited = False
         self._exit_reason = ""
 
-        # Completion flow state: set True after /complete, cleared after answer collected.
-        self._awaiting_completion_notes = False
-        self._completion_notes = ""
+        self._awaiting_prediction = False
+        self._predictions: list[str] = []
 
     @classmethod
     def create_from_context(cls, pc: CharacterRecord, npc: CharacterRecord, **kwargs: Any) -> "ForesightGame":
@@ -64,12 +63,8 @@ class ForesightGame(Game):
             retry_budget (int): overrides DEFAULT_RETRY_BUDGET
             max_input_length (int): overrides DEFAULT_MAX_INPUT_LENGTH
         """
-        updater = UpdaterClient(
-            system_prompt=build_updater_prompt(pc, npc, additional_rules=C.ADDITIONAL_UPDATER_RULES)
-        )
-        validator = ValidatorClient(
-            system_prompt_template=build_validator_prompt(pc, npc, additional_rules=C.ADDITIONAL_VALIDATOR_RULES)
-        )
+        updater = UpdaterClient(system_prompt=build_updater_prompt(pc, npc, additional_rules=C.ADDITIONAL_UPDATER_RULES))
+        validator = ValidatorClient(system_prompt_template=build_validator_prompt(pc, npc, additional_rules=C.ADDITIONAL_VALIDATOR_RULES))
         return cls(
             pc=pc,
             npc=npc,
@@ -98,16 +93,15 @@ class ForesightGame(Game):
         return self._exit_reason
 
     @property
-    def completion_notes(self) -> str:
-        """Notes collected from the player at game completion, or empty string."""
-        return self._completion_notes
+    def predictions(self) -> list[str]:
+        """Predictions recorded during play."""
+        return list(self._predictions)
 
     async def step(self, user_input: str | None = None) -> AsyncIterator[GameEvent]:
         """Advance the game one turn, yielding one or more GameEvents."""
         if self._exited:
             return
 
-        # ENTER: first call — emit welcome message then generate the opening scene.
         if not self._entered:
             self._entered = True
             yield GameEvent.now(
@@ -124,16 +118,12 @@ class ForesightGame(Game):
         if not user_input:
             return
 
-        # COMPLETION NOTES: collect the player's answer after /complete was typed.
-        if self._awaiting_completion_notes:
-            self._completion_notes = user_input
-            self._awaiting_completion_notes = False
-            self.exit("game completed")
-            yield GameEvent.now(type="info", content="Thank you. Game complete.")
+        if self._awaiting_prediction:
+            self._predictions.append(user_input)
+            self._awaiting_prediction = False
+            yield GameEvent.now(type="info", content=C.PREDICT_NEXT_CONFIRMATION)
             return
 
-        # Game-level commands (/help, /complete). Session-level exit commands
-        # are already handled by SessionManager.
         command_event = self._handle_command(user_input)
         if command_event is not None:
             yield command_event
@@ -146,7 +136,6 @@ class ForesightGame(Game):
             )
             return
 
-        # Validate before advancing the scene.
         validation = await self._validator.validate(user_input)
         if validation.get("type") == "error":
             self._retry_budget -= 1
@@ -178,15 +167,11 @@ class ForesightGame(Game):
         if cmd == Command.HELP:
             return GameEvent.now(type="info", content=C.HELP_CONTENT, command_response=True)
 
-        if cmd == Command.COMPLETE:
+        if cmd == Command.PREDICT_NEXT:
             if remainder:
-                self._completion_notes = remainder
-                self._awaiting_completion_notes = False
-                self.exit("game completed")
-                return GameEvent.now(type="info", content="Thank you. Game complete.", command_response=True)
-            # Transition to completion-notes collection on the next turn.
-            self._awaiting_completion_notes = True
-            return GameEvent.now(type="info", content=C.COMPLETE_QUESTION, command_response=True)
+                self._predictions.append(remainder)
+                return GameEvent.now(type="info", content=C.PREDICT_NEXT_CONFIRMATION, command_response=True)
+            self._awaiting_prediction = True
+            return GameEvent.now(type="info", content=C.PREDICT_NEXT_QUESTION, command_response=True)
 
-        # Unrecognised — return None so SessionManager can handle it.
         return None

--- a/dcs_simulation_engine/games/goal_horizon.py
+++ b/dcs_simulation_engine/games/goal_horizon.py
@@ -12,7 +12,6 @@ from dcs_simulation_engine.games.ai_client import (
 from dcs_simulation_engine.games.const import (
     GoalHorizon as C,
 )
-from dcs_simulation_engine.games.markdown_helpers import format_abilities_markdown
 from dcs_simulation_engine.games.prompts import (
     build_updater_prompt,
     build_validator_prompt,
@@ -24,11 +23,11 @@ class Command(StrEnum):
     """Game-level slash commands recognised by GoalHorizonGame."""
 
     HELP = "help"
-    ABILITIES = "abilities"
+    PREDICT_CAPABILITIES = "predict-capabilities"
 
 
 class GoalHorizonGame(Game):
-    """Goal Horizon game: player interacts with NPC across scenes to understand their goalspace."""
+    """Goal Horizon game: player interacts with NPC across scenes to understand their limits."""
 
     DEFAULT_RETRY_BUDGET = 10
     DEFAULT_MAX_INPUT_LENGTH = 350
@@ -52,6 +51,8 @@ class GoalHorizonGame(Game):
         self._entered = False
         self._exited = False
         self._exit_reason = ""
+        self._awaiting_capability_prediction = False
+        self._capability_prediction = ""
 
     @classmethod
     def create_from_context(cls, pc: CharacterRecord, npc: CharacterRecord, **kwargs: Any) -> "GoalHorizonGame":
@@ -90,12 +91,16 @@ class GoalHorizonGame(Game):
         """Reason the game ended, or empty string."""
         return self._exit_reason
 
+    @property
+    def capability_prediction(self) -> str:
+        """Player's inferred capability limits, or empty string."""
+        return self._capability_prediction
+
     async def step(self, user_input: str | None = None) -> AsyncIterator[GameEvent]:
         """Advance the game one turn, yielding one or more GameEvents."""
         if self._exited:
             return
 
-        # ENTER: first call — emit welcome message then generate the opening scene.
         if not self._entered:
             self._entered = True
             yield GameEvent.now(
@@ -114,8 +119,13 @@ class GoalHorizonGame(Game):
         if not user_input:
             return
 
-        # Game-level commands (/help, /abilities). Session-level exit commands
-        # are already handled by SessionManager.
+        if self._awaiting_capability_prediction:
+            self._capability_prediction = user_input
+            self._awaiting_capability_prediction = False
+            self.exit("game completed")
+            yield GameEvent.now(type="info", content="Thank you. Game complete.")
+            return
+
         command_event = self._handle_command(user_input)
         if command_event is not None:
             yield command_event
@@ -128,7 +138,6 @@ class GoalHorizonGame(Game):
             )
             return
 
-        # Validate before advancing the scene.
         validation = await self._validator.validate(user_input)
         if validation.get("type") == "error":
             self._retry_budget -= 1
@@ -153,24 +162,19 @@ class GoalHorizonGame(Game):
         command_body = stripped[1:].strip()
         if not command_body:
             return None
-        cmd = command_body.split()[0].lower()
+        parts = command_body.split(maxsplit=1)
+        cmd = parts[0].lower()
+        remainder = parts[1].strip() if len(parts) > 1 else ""
 
         if cmd == Command.HELP:
             return GameEvent.now(type="info", content=C.HELP_CONTENT, command_response=True)
+        if cmd == Command.PREDICT_CAPABILITIES:
+            if remainder:
+                self._capability_prediction = remainder
+                self._awaiting_capability_prediction = False
+                self.exit("game completed")
+                return GameEvent.now(type="info", content="Thank you. Game complete.", command_response=True)
+            self._awaiting_capability_prediction = True
+            return GameEvent.now(type="info", content=C.CAPABILITY_PREDICTION_QUESTION, command_response=True)
 
-        if cmd == Command.ABILITIES:
-            return GameEvent.now(
-                type="info",
-                content=C.ABILITIES_CONTENT.format(
-                    pc_hid=self._pc.hid,
-                    pc_short_description=self._pc.short_description,
-                    pc_abilities=format_abilities_markdown(self._pc.data.get("abilities", "")),
-                    npc_hid=self._npc.hid,
-                    npc_short_description=self._npc.short_description,
-                    npc_abilities=format_abilities_markdown(self._npc.data.get("abilities", "")),
-                ),
-                command_response=True,
-            )
-
-        # Unrecognised — return None so SessionManager can handle it.
         return None

--- a/dcs_simulation_engine/games/infer_intent.py
+++ b/dcs_simulation_engine/games/infer_intent.py
@@ -12,7 +12,6 @@ from dcs_simulation_engine.games.ai_client import (
 from dcs_simulation_engine.games.const import (
     InferIntent as C,
 )
-from dcs_simulation_engine.games.markdown_helpers import format_abilities_markdown
 from dcs_simulation_engine.games.prompts import (
     build_updater_prompt,
     build_validator_prompt,
@@ -24,8 +23,7 @@ class Command(StrEnum):
     """Game-level slash commands recognised by InferIntentGame."""
 
     HELP = "help"
-    ABILITIES = "abilities"
-    GUESS = "guess"
+    PREDICT_INTENT = "predict-intent"
 
 
 class InferIntentGame(Game):
@@ -54,7 +52,6 @@ class InferIntentGame(Game):
         self._exited = False
         self._exit_reason = ""
 
-        # Completion flow state
         self._awaiting_goal_inference = False
         self._awaiting_other_feedback = False
         self._goal_inference = ""
@@ -69,9 +66,7 @@ class InferIntentGame(Game):
             retry_budget (int): overrides DEFAULT_RETRY_BUDGET
             max_input_length (int): overrides DEFAULT_MAX_INPUT_LENGTH
         """
-        updater = UpdaterClient(
-            system_prompt=build_updater_prompt(pc, npc, additional_rules=C.ADDITIONAL_UPDATER_RULES)
-        )
+        updater = UpdaterClient(system_prompt=build_updater_prompt(pc, npc, additional_rules=C.ADDITIONAL_UPDATER_RULES))
         validator = ValidatorClient(system_prompt_template=build_validator_prompt(pc, npc))
         return cls(
             pc=pc,
@@ -120,7 +115,6 @@ class InferIntentGame(Game):
         if self._exited:
             return
 
-        # ENTER: first call — emit welcome message then generate the opening scene.
         if not self._entered:
             self._entered = True
             yield GameEvent.now(
@@ -137,7 +131,6 @@ class InferIntentGame(Game):
         if not user_input:
             return
 
-        # GOAL INFERENCE: first answer after /guess.
         if self._awaiting_goal_inference:
             self._goal_inference = user_input
             self._awaiting_goal_inference = False
@@ -145,7 +138,6 @@ class InferIntentGame(Game):
             yield GameEvent.now(type="info", content=C.OTHER_FEEDBACK_QUESTION)
             return
 
-        # OTHER FEEDBACK: second answer — then score and exit.
         if self._awaiting_other_feedback:
             self._other_feedback = user_input
             self._awaiting_other_feedback = False
@@ -153,8 +145,6 @@ class InferIntentGame(Game):
             yield GameEvent.now(type="info", content="Thank you. Game complete.")
             return
 
-        # Game-level commands (/help, /abilities, /guess). Session-level exit
-        # commands are already handled by SessionManager.
         command_event = self._handle_command(user_input)
         if command_event is not None:
             yield command_event
@@ -167,7 +157,6 @@ class InferIntentGame(Game):
             )
             return
 
-        # Validate before advancing the scene.
         validation = await self._validator.validate(user_input)
         if validation.get("type") == "error":
             self._retry_budget -= 1
@@ -197,18 +186,8 @@ class InferIntentGame(Game):
         if cmd == Command.HELP:
             return GameEvent.now(type="info", content=C.HELP_CONTENT, command_response=True)
 
-        if cmd == Command.ABILITIES:
-            return GameEvent.now(
-                type="info",
-                content=C.ABILITIES_CONTENT.format(
-                    pc_abilities=format_abilities_markdown(self._pc.data.get("abilities", ""))
-                ),
-                command_response=True,
-            )
-
-        if cmd == Command.GUESS:
+        if cmd == Command.PREDICT_INTENT:
             self._awaiting_goal_inference = True
             return GameEvent.now(type="info", content=C.GOAL_INFERENCE_QUESTION, command_response=True)
 
-        # Unrecognised — return None so SessionManager can handle it.
         return None

--- a/dcs_simulation_engine/helpers/game_helpers.py
+++ b/dcs_simulation_engine/helpers/game_helpers.py
@@ -168,8 +168,7 @@ def get_game_config(game: str, version: str = "latest") -> str:
 
         available_versions = sorted({str(doc.get("version", "")).strip() or "<none>" for _, doc in matches})
         raise FileNotFoundError(
-            f"No game config for {game!r} with version {version!r} found. "
-            f"Available versions for this game: {available_versions}"
+            f"No game config for {game!r} with version {version!r} found. Available versions for this game: {available_versions}"
         )
 
     # version == "latest": pick the latest stable release.
@@ -205,9 +204,7 @@ def get_game_config(game: str, version: str = "latest") -> str:
     if versioned_others:
         v, chosen_path = max(versioned_others, key=lambda x: x[0])
         chosen = str(chosen_path)
-        logger.debug(
-            f"No stable versions for {game!r}. Selected latest non-stable game config {chosen} with version={v}."
-        )
+        logger.debug(f"No stable versions for {game!r}. Selected latest non-stable game config {chosen} with version={v}.")
         return chosen
 
     # No parseable versions at all: fall back to latest by modification time.

--- a/dcs_simulation_engine/infra/fly.py
+++ b/dcs_simulation_engine/infra/fly.py
@@ -163,9 +163,7 @@ def ensure_fly_auth() -> None:
     except FileNotFoundError:
         raise FlyError("flyctl not found. Please install flyctl and ensure it's on your PATH.")
     except Exception as e:
-        raise FlyError(
-            "Failed to verify Fly authentication. Please ensure you're logged in via `fly auth login`."
-        ) from e
+        raise FlyError("Failed to verify Fly authentication. Please ensure you're logged in via `fly auth login`.") from e
 
 
 def load_env(env_file: Optional[Path] = Path(".env")) -> LoadedEnv:

--- a/dcs_simulation_engine/infra/remote.py
+++ b/dcs_simulation_engine/infra/remote.py
@@ -177,9 +177,7 @@ def _normalize_deploy_apps(deploy_apps: set[str] | None) -> list[str]:
     normalized = {app.strip().lower() for app in deploy_apps if app.strip()}
     invalid = sorted(normalized.difference(REMOTE_DEPLOY_APP_ORDER))
     if invalid:
-        raise RemoteLifecycleError(
-            f"deploy_apps must be drawn from {', '.join(REMOTE_DEPLOY_APP_ORDER)}; got {', '.join(invalid)}."
-        )
+        raise RemoteLifecycleError(f"deploy_apps must be drawn from {', '.join(REMOTE_DEPLOY_APP_ORDER)}; got {', '.join(invalid)}.")
     return [app for app in REMOTE_DEPLOY_APP_ORDER if app in normalized]
 
 
@@ -485,9 +483,7 @@ def _validate_mongo_seed_path(path: Path) -> Path:
     if resolved.suffix.lower() in {".json", ".ndjson"}:
         return resolved
 
-    raise RemoteLifecycleError(
-        "mongo_seed_path must be a directory, a .zip/.tar.gz/.tgz/.tar archive, or a .json/.ndjson file."
-    )
+    raise RemoteLifecycleError("mongo_seed_path must be a directory, a .zip/.tar.gz/.tgz/.tar archive, or a .json/.ndjson file.")
 
 
 @contextmanager

--- a/dcs_simulation_engine/utils/auth.py
+++ b/dcs_simulation_engine/utils/auth.py
@@ -23,7 +23,5 @@ def validate_access_key(raw_key: str) -> str:
     if not key.startswith(DEFAULT_KEY_PREFIX):
         raise ValueError(f"Admin key must start with '{DEFAULT_KEY_PREFIX}'.")
     if not ACCESS_KEY_PATTERN.fullmatch(key):
-        raise ValueError(
-            "Admin key must use only URL-safe alphanumeric characters after the prefix (A-Z, a-z, 0-9, '_' or '-')."
-        )
+        raise ValueError("Admin key must use only URL-safe alphanumeric characters after the prefix (A-Z, a-z, 0-9, '_' or '-').")
     return key

--- a/deployments/free-play/dcs-free-play-api.fly.toml
+++ b/deployments/free-play/dcs-free-play-api.fly.toml
@@ -1,10 +1,10 @@
 app = "dcs-free-play-api"
-primary_region = "lax"
+primary_region = "iad"
 [build]
   dockerfile = "../../docker/api.dockerfile"
 
 [processes]
-  app = "dcs server --host 0.0.0.0 --port 8000 --remote-managed --free-play --bootstrap-token dcs-bootstrap-free-play-IaMR0HqKFR9O5Ilu --cors-origin https://dcs-free-play-ui.fly.dev"
+  app = "dcs server --host 0.0.0.0 --port 8000 --remote-managed --free-play --bootstrap-token dcs-bootstrap-free-play-uK4MYCsrkZlJpmpE --cors-origin https://dcs-free-play-ui.fly.dev"
 
 [http_service]
   internal_port = 8000
@@ -17,4 +17,4 @@ primary_region = "lax"
 [[vm]]
   cpu_kind = "shared"
   cpus = 1
-  memory = "1gb"
+  memory = "512mb"

--- a/deployments/free-play/dcs-free-play-db.fly.toml
+++ b/deployments/free-play/dcs-free-play-db.fly.toml
@@ -1,5 +1,5 @@
 app = "dcs-free-play-db"
-primary_region = "lax"
+primary_region = "iad"
 [build]
   dockerfile = "../../docker/mongo.fly.dockerfile"
 
@@ -18,4 +18,4 @@ primary_region = "lax"
 [[vm]]
   cpu_kind = "shared"
   cpus = 1
-  memory = "1gb"
+  memory = "512mb"

--- a/deployments/free-play/dcs-free-play-ui.fly.toml
+++ b/deployments/free-play/dcs-free-play-ui.fly.toml
@@ -1,5 +1,5 @@
 app = "dcs-free-play-ui"
-primary_region = "lax"
+primary_region = "iad"
 [build]
   dockerfile = "../../docker/ui.fly.dockerfile"
 

--- a/deployments/usability-ca/dcs-usability-ca-api.fly.toml
+++ b/deployments/usability-ca/dcs-usability-ca-api.fly.toml
@@ -1,10 +1,10 @@
 app = "dcs-usability-ca-api"
-primary_region = "lax"
+primary_region = "iad"
 [build]
   dockerfile = "../../docker/api.dockerfile"
 
 [processes]
-  app = "dcs server --host 0.0.0.0 --port 8000 --remote-managed --default-experiment usability-ca --bootstrap-token dcs-bootstrap-usability-ca-qteImCBV1hAt6UMY --cors-origin https://dcs-usability-ca-ui.fly.dev"
+  app = "dcs server --host 0.0.0.0 --port 8000 --remote-managed --default-experiment usability-ca --bootstrap-token dcs-bootstrap-usability-ca-UK8NKj6C-n4cddYJ --cors-origin https://dcs-usability-ca-ui.fly.dev"
 
 [http_service]
   internal_port = 8000
@@ -17,4 +17,4 @@ primary_region = "lax"
 [[vm]]
   cpu_kind = "shared"
   cpus = 1
-  memory = "1gb"
+  memory = "512mb"

--- a/deployments/usability-ca/dcs-usability-ca-db.fly.toml
+++ b/deployments/usability-ca/dcs-usability-ca-db.fly.toml
@@ -1,5 +1,5 @@
 app = "dcs-usability-ca-db"
-primary_region = "lax"
+primary_region = "iad"
 [build]
   dockerfile = "../../docker/mongo.fly.dockerfile"
 
@@ -18,4 +18,4 @@ primary_region = "lax"
 [[vm]]
   cpu_kind = "shared"
   cpus = 1
-  memory = "1gb"
+  memory = "512mb"

--- a/deployments/usability-ca/dcs-usability-ca-ui.fly.toml
+++ b/deployments/usability-ca/dcs-usability-ca-ui.fly.toml
@@ -1,5 +1,5 @@
 app = "dcs-usability-ca-ui"
-primary_region = "lax"
+primary_region = "iad"
 [build]
   dockerfile = "../../docker/ui.fly.dockerfile"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ profile = "black"
 
 
 [tool.ruff]
-line-length = 120
+line-length = 140
 src = ["dcs_simulation_engine", "tests"]
 exclude = [
   "analysis/*", # analysis folder

--- a/tests/api/test_infer_intent_evaluation_service.py
+++ b/tests/api/test_infer_intent_evaluation_service.py
@@ -34,8 +34,8 @@ def _event(
 
 
 @pytest.mark.unit
-def test_extract_infer_intent_scoring_inputs_uses_only_gameplay_before_guess() -> None:
-    """Transcript reconstruction ignores commands, hidden events, and post-guess feedback."""
+def test_extract_infer_intent_scoring_inputs_uses_only_gameplay_before_prediction() -> None:
+    """Transcript reconstruction ignores commands, hidden events, and post-prediction feedback."""
     events = [
         _event(
             seq=9,
@@ -64,8 +64,8 @@ def test_extract_infer_intent_scoring_inputs_uses_only_gameplay_before_guess() -
             direction="outbound",
             event_type="command",
             event_source="system",
-            content="What do you think the NPC's goal or intention was?",
-            data={MongoColumns.VISIBLE_TO_USER: True, MongoColumns.COMMAND_NAME: "guess"},
+            content="What do you think the character's goal or intention was?",
+            data={MongoColumns.VISIBLE_TO_USER: True, MongoColumns.COMMAND_NAME: "predict-intent"},
         ),
         _event(
             seq=3,
@@ -87,8 +87,8 @@ def test_extract_infer_intent_scoring_inputs_uses_only_gameplay_before_guess() -
             direction="inbound",
             event_type="command",
             event_source="user",
-            content="/guess",
-            data={MongoColumns.VISIBLE_TO_USER: True, MongoColumns.COMMAND_NAME: "guess"},
+            content="/predict-intent",
+            data={MongoColumns.VISIBLE_TO_USER: True, MongoColumns.COMMAND_NAME: "predict-intent"},
         ),
         _event(
             seq=7,
@@ -119,8 +119,8 @@ def test_extract_infer_intent_scoring_inputs_uses_only_gameplay_before_guess() -
 
 
 @pytest.mark.unit
-def test_extract_infer_intent_scoring_inputs_requires_saved_guess_command() -> None:
-    """A completed evaluation cannot be reconstructed without the saved /guess command."""
+def test_extract_infer_intent_scoring_inputs_requires_saved_prediction_command() -> None:
+    """A completed evaluation cannot be reconstructed without the saved prediction command."""
     events = [
         _event(
             seq=1,
@@ -138,5 +138,5 @@ def test_extract_infer_intent_scoring_inputs_requires_saved_guess_command() -> N
         ),
     ]
 
-    with pytest.raises(InferIntentEvaluationUnavailableError, match="no guess was saved"):
+    with pytest.raises(InferIntentEvaluationUnavailableError, match="no prediction was saved"):
         extract_infer_intent_scoring_inputs(events)

--- a/tests/api/test_server.py
+++ b/tests/api/test_server.py
@@ -675,8 +675,8 @@ def test_infer_intent_evaluation_endpoint_generates_then_returns_cached_result(
             direction="inbound",
             event_type="command",
             event_source="user",
-            content="/guess",
-            data={MongoColumns.VISIBLE_TO_USER: True, MongoColumns.COMMAND_NAME: "guess"},
+            content="/predict-intent",
+            data={MongoColumns.VISIBLE_TO_USER: True, MongoColumns.COMMAND_NAME: "predict-intent"},
         ),
         _session_event(
             seq=5,
@@ -684,7 +684,7 @@ def test_infer_intent_evaluation_endpoint_generates_then_returns_cached_result(
             event_type="command",
             event_source="system",
             content="What do you think the NPC's goal or intention was?",
-            data={MongoColumns.VISIBLE_TO_USER: True, MongoColumns.COMMAND_NAME: "guess"},
+            data={MongoColumns.VISIBLE_TO_USER: True, MongoColumns.COMMAND_NAME: "predict-intent"},
         ),
         _session_event(
             seq=6,
@@ -825,8 +825,8 @@ def test_infer_intent_evaluation_endpoint_supports_free_play_sessions(
             direction="inbound",
             event_type="command",
             event_source="user",
-            content="/guess",
-            data={MongoColumns.VISIBLE_TO_USER: True, MongoColumns.COMMAND_NAME: "guess"},
+            content="/predict-intent",
+            data={MongoColumns.VISIBLE_TO_USER: True, MongoColumns.COMMAND_NAME: "predict-intent"},
         ),
         _session_event(
             seq=5,
@@ -834,7 +834,7 @@ def test_infer_intent_evaluation_endpoint_supports_free_play_sessions(
             event_type="command",
             event_source="system",
             content="What do you think the NPC's goal or intention was?",
-            data={MongoColumns.VISIBLE_TO_USER: True, MongoColumns.COMMAND_NAME: "guess"},
+            data={MongoColumns.VISIBLE_TO_USER: True, MongoColumns.COMMAND_NAME: "predict-intent"},
         ),
         _session_event(
             seq=6,

--- a/tests/api_manual/infer_intent_eval.py
+++ b/tests/api_manual/infer_intent_eval.py
@@ -139,9 +139,7 @@ def main() -> None:
         with connect(ws_url, **connect_kwargs) as ws:
             opening_events, opening_frame = _recv_until_turn_end(ws)
             _print_events(opening_events)
-            print(
-                f"   opening: turns={opening_frame.get('turns')} exited={opening_frame.get('exited', False)}"
-            )
+            print(f"   opening: turns={opening_frame.get('turns')} exited={opening_frame.get('exited', False)}")
 
             for idx, turn in enumerate(turns, start=1):
                 print(f"   turn {idx}: {turn}")
@@ -149,8 +147,8 @@ def main() -> None:
                 _print_events(step_events)
                 print(f"   turn_end: turns={step_frame.get('turns')} exited={step_frame.get('exited', False)}")
 
-            print("   command: /guess")
-            guess_events, guess_frame = _send_advance(ws, "/guess")
+            print("   command: /predict-intent")
+            guess_events, guess_frame = _send_advance(ws, "/predict-intent")
             _print_events(guess_events)
             print(f"   turn_end: turns={guess_frame.get('turns')} exited={guess_frame.get('exited', False)}")
 

--- a/tests/cli/test_remote_command.py
+++ b/tests/cli/test_remote_command.py
@@ -18,13 +18,7 @@ def test_remote_deploy_command_outputs_json(monkeypatch: pytest.MonkeyPatch, tmp
     config_path = tmp_path / "experiment.yaml"
     seed_path = tmp_path / "seed.json"
     config_path.write_text(
-        (
-            "name: usability-ca\n"
-            "assignment_strategy:\n"
-            "  strategy: random_unique\n"
-            "  games: [explore]\n"
-            "  quota_per_game: 1\n"
-        ),
+        ("name: usability-ca\nassignment_strategy:\n  strategy: random_unique\n  games: [explore]\n  quota_per_game: 1\n"),
         encoding="utf-8",
     )
     seed_path.write_text("[]", encoding="utf-8")
@@ -75,13 +69,7 @@ def test_remote_deploy_command_passes_targeted_apps(monkeypatch: pytest.MonkeyPa
     config_path = tmp_path / "experiment.yaml"
     seed_path = tmp_path / "seed.json"
     config_path.write_text(
-        (
-            "name: usability-ca\n"
-            "assignment_strategy:\n"
-            "  strategy: random_unique\n"
-            "  games: [explore]\n"
-            "  quota_per_game: 1\n"
-        ),
+        ("name: usability-ca\nassignment_strategy:\n  strategy: random_unique\n  games: [explore]\n  quota_per_game: 1\n"),
         encoding="utf-8",
     )
     seed_path.write_text("[]", encoding="utf-8")
@@ -127,9 +115,7 @@ def test_remote_deploy_command_passes_targeted_apps(monkeypatch: pytest.MonkeyPa
 
 
 @pytest.mark.unit
-def test_remote_deploy_command_supports_free_play_without_config(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_remote_deploy_command_supports_free_play_without_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Remote deploy should allow free-play mode without an experiment config."""
     seed_path = tmp_path / "seed.json"
     seed_path.write_text("[]", encoding="utf-8")
@@ -177,13 +163,7 @@ def test_remote_deploy_command_prints_admin_key_once(monkeypatch: pytest.MonkeyP
     config_path = tmp_path / "experiment.yaml"
     seed_path = tmp_path / "seed.json"
     config_path.write_text(
-        (
-            "name: usability-ca\n"
-            "assignment_strategy:\n"
-            "  strategy: random_unique\n"
-            "  games: [explore]\n"
-            "  quota_per_game: 1\n"
-        ),
+        ("name: usability-ca\nassignment_strategy:\n  strategy: random_unique\n  games: [explore]\n  quota_per_game: 1\n"),
         encoding="utf-8",
     )
     seed_path.write_text("[]", encoding="utf-8")
@@ -230,13 +210,7 @@ def test_remote_deploy_command_passes_explicit_admin_key(monkeypatch: pytest.Mon
     config_path = tmp_path / "experiment.yaml"
     seed_path = tmp_path / "seed.json"
     config_path.write_text(
-        (
-            "name: usability-ca\n"
-            "assignment_strategy:\n"
-            "  strategy: random_unique\n"
-            "  games: [explore]\n"
-            "  quota_per_game: 1\n"
-        ),
+        ("name: usability-ca\nassignment_strategy:\n  strategy: random_unique\n  games: [explore]\n  quota_per_game: 1\n"),
         encoding="utf-8",
     )
     seed_path.write_text("[]", encoding="utf-8")
@@ -280,20 +254,12 @@ def test_remote_deploy_command_passes_explicit_admin_key(monkeypatch: pytest.Mon
 
 
 @pytest.mark.unit
-def test_remote_deploy_command_retries_regions_on_capacity_errors(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
+def test_remote_deploy_command_retries_regions_on_capacity_errors(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """Remote deploy should try later regions when Fly reports capacity exhaustion."""
     config_path = tmp_path / "experiment.yaml"
     seed_path = tmp_path / "seed.json"
     config_path.write_text(
-        (
-            "name: usability-ca\n"
-            "assignment_strategy:\n"
-            "  strategy: random_unique\n"
-            "  games: [explore]\n"
-            "  quota_per_game: 1\n"
-        ),
+        ("name: usability-ca\nassignment_strategy:\n  strategy: random_unique\n  games: [explore]\n  quota_per_game: 1\n"),
         encoding="utf-8",
     )
     seed_path.write_text("[]", encoding="utf-8")

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -10,9 +10,7 @@ from dcs_simulation_engine.core.experiment_manager import ExperimentManager
 
 
 @pytest.fixture
-def game_config_minimal(
-    write_yaml: Callable[[Path, str], Path], tmp_path_factory: pytest.TempPathFactory
-) -> SimpleNamespace:
+def game_config_minimal(write_yaml: Callable[[Path, str], Path], tmp_path_factory: pytest.TempPathFactory) -> SimpleNamespace:
     """Fixture for a minimal base GameConfig."""
     base = tmp_path_factory.mktemp("cfg_minimal")
     game_config_yaml = """

--- a/tests/core/test_experiment_manager.py
+++ b/tests/core/test_experiment_manager.py
@@ -20,9 +20,7 @@ def _entry_form_payload() -> dict[str, dict[str, object]]:
     }
 
 
-async def test_submit_before_play_stores_entry_form_on_assignment(
-    async_mongo_provider, cached_usability_experiment
-) -> None:
+async def test_submit_before_play_stores_entry_form_on_assignment(async_mongo_provider, cached_usability_experiment) -> None:
     """Submitting before-play answers should persist the form on the player's assignment."""
     player, _ = await async_mongo_provider.create_player(player_data={"full_name": {"answer": "Ada Lovelace"}})
     assignment = await ExperimentManager.submit_before_play_async(
@@ -60,9 +58,7 @@ async def test_interrupted_assignment_is_reused(async_mongo_provider, cached_usa
     assert second.assignment_id == first.assignment_id
 
 
-async def test_completed_assignment_blocks_further_assignment_when_max_is_one(
-    async_mongo_provider, cached_usability_experiment
-) -> None:
+async def test_completed_assignment_blocks_further_assignment_when_max_is_one(async_mongo_provider, cached_usability_experiment) -> None:
     """A player should stop receiving assignments after one completed game when max_assignments=1."""
     player, _ = await async_mongo_provider.create_player(player_data={"full_name": {"answer": "Bob"}})
     assignment = await ExperimentManager.get_or_create_assignment_async(
@@ -127,9 +123,7 @@ async def test_post_play_completion_marks_experiment_finished_after_single_assig
     assert state["has_finished_experiment"] is True
 
 
-async def test_progress_counts_completed_assignments_and_unique_players(
-    async_mongo_provider, cached_usability_experiment
-) -> None:
+async def test_progress_counts_completed_assignments_and_unique_players(async_mongo_provider, cached_usability_experiment) -> None:
     """Experiment progress should report total, completed rows, and per-game unique-player counts."""
     player_a, _ = await async_mongo_provider.create_player(player_data={"full_name": {"answer": "A"}})
     player_b, _ = await async_mongo_provider.create_player(player_data={"full_name": {"answer": "B"}})
@@ -167,16 +161,12 @@ async def test_progress_counts_completed_assignments_and_unique_players(
         experiment_name=cached_usability_experiment.name,
     )
 
-    assert progress["total"] == cached_usability_experiment.assignment_strategy.quota_per_game * len(
-        cached_usability_experiment.games
-    )
+    assert progress["total"] == cached_usability_experiment.assignment_strategy.quota_per_game * len(cached_usability_experiment.games)
     assert progress["completed"] == 2
     assert progress["is_complete"] is False
 
 
-async def test_status_empty_experiment_reports_open_quota_totals(
-    async_mongo_provider, cached_usability_experiment
-) -> None:
+async def test_status_empty_experiment_reports_open_quota_totals(async_mongo_provider, cached_usability_experiment) -> None:
     """Experiment status should report zero live counts before any assignments exist."""
     quota = cached_usability_experiment.assignment_strategy.quota_per_game or 0
 
@@ -191,9 +181,7 @@ async def test_status_empty_experiment_reports_open_quota_totals(
     assert status_payload["per_game"]["Explore"] == {"total": quota, "completed": 0, "in_progress": 0}
 
 
-async def test_status_counts_completed_and_in_progress_per_game(
-    async_mongo_provider, cached_usability_experiment
-) -> None:
+async def test_status_counts_completed_and_in_progress_per_game(async_mongo_provider, cached_usability_experiment) -> None:
     """Experiment status should split completed and in-progress unique-player counts by game."""
     quota = cached_usability_experiment.assignment_strategy.quota_per_game or 0
     player_a, _ = await async_mongo_provider.create_player(player_data={"full_name": {"answer": "A"}})
@@ -254,9 +242,7 @@ async def test_status_counts_completed_and_in_progress_per_game(
     assert status_payload["per_game"]["Foresight"] == {"total": quota, "completed": 1, "in_progress": 0}
 
 
-async def test_status_deduplicates_completed_players_per_game(
-    async_mongo_provider, cached_usability_experiment
-) -> None:
+async def test_status_deduplicates_completed_players_per_game(async_mongo_provider, cached_usability_experiment) -> None:
     """Completed counts should be unique by player within each game."""
     quota = cached_usability_experiment.assignment_strategy.quota_per_game or 0
     player, _ = await async_mongo_provider.create_player(player_data={"full_name": {"answer": "A"}})
@@ -298,9 +284,7 @@ async def test_status_deduplicates_completed_players_per_game(
     assert status_payload["per_game"]["Explore"] == {"total": quota, "completed": 1, "in_progress": 0}
 
 
-async def test_stopping_condition_reason_marks_assignment_completed(
-    async_mongo_provider, cached_usability_experiment
-) -> None:
+async def test_stopping_condition_reason_marks_assignment_completed(async_mongo_provider, cached_usability_experiment) -> None:
     """Stopping-condition exits should count as experiment completion."""
     player, _ = await async_mongo_provider.create_player(player_data={"full_name": {"answer": "A"}})
     assignment = await async_mongo_provider.create_assignment(
@@ -352,9 +336,7 @@ async def test_compute_status_dispatches_to_assignment_strategy(
 ) -> None:
     """ExperimentManager should delegate status calculation to the configured strategy."""
     strategy = MagicMock()
-    strategy.compute_status_async = AsyncMock(
-        return_value={"is_open": True, "total": 4, "completed": 1, "per_game": {}}
-    )
+    strategy.compute_status_async = AsyncMock(return_value={"is_open": True, "total": 4, "completed": 1, "per_game": {}})
 
     monkeypatch.setattr("dcs_simulation_engine.core.experiment_manager.get_assignment_strategy", lambda _name: strategy)
 

--- a/tests/core/test_random_unique_assignment_strategy.py
+++ b/tests/core/test_random_unique_assignment_strategy.py
@@ -200,9 +200,7 @@ async def test_random_unique_interrupted_rows_release_quota(async_mongo_provider
         character_hid="test-char-a",
         status="in_progress",
     )
-    interrupted = await async_mongo_provider.get_active_assignment(
-        experiment_name=config.name, player_id=first_player.id
-    )
+    interrupted = await async_mongo_provider.get_active_assignment(experiment_name=config.name, player_id=first_player.id)
     assert interrupted is not None
     await async_mongo_provider.update_assignment_status(
         assignment_id=interrupted.assignment_id,

--- a/tests/core/test_session_event_recorder.py
+++ b/tests/core/test_session_event_recorder.py
@@ -172,9 +172,7 @@ async def test_session_event_recorder_records_sequence_and_finalize() -> None:
     assert events_docs[1]["event_id"] == info_outbound.event_id
     assert events_docs[1]["event_ts"] == explicit_event_ts
     assistant_doc = next(
-        doc
-        for doc in events_docs
-        if doc["direction"] == "outbound" and doc["event_type"] == "message" and doc["event_source"] == "npc"
+        doc for doc in events_docs if doc["direction"] == "outbound" and doc["event_type"] == "message" and doc["event_source"] == "npc"
     )
     assert assistant_doc["event_id"] == ai_outbound.event_id
     assert (
@@ -185,8 +183,7 @@ async def test_session_event_recorder_records_sequence_and_finalize() -> None:
         is False
     )
     assert any(
-        doc["direction"] == "internal" and doc["event_type"] == "session_end" and doc["event_source"] == "system"
-        for doc in events_docs
+        doc["direction"] == "internal" and doc["event_type"] == "session_end" and doc["event_source"] == "system" for doc in events_docs
     )
 
 

--- a/tests/core/test_session_manager_command_filter_persistence.py
+++ b/tests/core/test_session_manager_command_filter_persistence.py
@@ -119,12 +119,11 @@ def consenting_player_id(async_mongo_provider: Any) -> str:
         ("Explore", f"/{ExploreCommand.HELP.value}", ExploreCommand.HELP.value),
         ("Explore", f"/{ExploreCommand.ABILITIES.value}", ExploreCommand.ABILITIES.value),
         ("Foresight", f"/{ForesightCommand.HELP.value}", ForesightCommand.HELP.value),
-        ("Foresight", f"/{ForesightCommand.COMPLETE.value}", ForesightCommand.COMPLETE.value),
+        ("Foresight", f"/{ForesightCommand.PREDICT_NEXT.value}", ForesightCommand.PREDICT_NEXT.value),
         ("Infer Intent", f"/{InferIntentCommand.HELP.value}", InferIntentCommand.HELP.value),
-        ("Infer Intent", f"/{InferIntentCommand.ABILITIES.value}", InferIntentCommand.ABILITIES.value),
-        ("Infer Intent", f"/{InferIntentCommand.GUESS.value}", InferIntentCommand.GUESS.value),
+        ("Infer Intent", f"/{InferIntentCommand.PREDICT_INTENT.value}", InferIntentCommand.PREDICT_INTENT.value),
         ("Goal Horizon", f"/{GoalHorizonCommand.HELP.value}", GoalHorizonCommand.HELP.value),
-        ("Goal Horizon", f"/{GoalHorizonCommand.ABILITIES.value}", GoalHorizonCommand.ABILITIES.value),
+        ("Goal Horizon", f"/{GoalHorizonCommand.PREDICT_CAPABILITIES.value}", GoalHorizonCommand.PREDICT_CAPABILITIES.value),
     ],
 )
 async def test_game_level_command_filters_persist_command_events(

--- a/tests/core/test_session_manager_run_persistence.py
+++ b/tests/core/test_session_manager_run_persistence.py
@@ -179,10 +179,7 @@ async def test_session_events_persist_normal_turn_with_user_and_npc_messages(
         session_id="session-normal-turn",
         inputs=["", "I look around"],
     )
-    assert any(
-        row["direction"] == "internal" and row["event_source"] == "system" and row["event_type"] == "session_start"
-        for row in rows
-    )
+    assert any(row["direction"] == "internal" and row["event_source"] == "system" and row["event_type"] == "session_start" for row in rows)
     assert any(
         row["direction"] == "inbound"
         and row["event_source"] == "user"
@@ -197,10 +194,7 @@ async def test_session_events_persist_normal_turn_with_user_and_npc_messages(
         and row["content"] == "The flatworm moves slowly across the surface."
         for row in rows
     )
-    assert any(
-        row["direction"] == "internal" and row["event_source"] == "system" and row["event_type"] == "session_end"
-        for row in rows
-    )
+    assert any(row["direction"] == "internal" and row["event_source"] == "system" and row["event_type"] == "session_end" for row in rows)
 
 
 async def test_session_events_persist_recognized_commands_as_command_rows(
@@ -224,10 +218,7 @@ async def test_session_events_persist_recognized_commands_as_command_rows(
         inputs=["", "/help"],
     )
     assert any(
-        row["direction"] == "inbound"
-        and row["event_source"] == "user"
-        and row["event_type"] == "command"
-        and row["content"] == "/help"
+        row["direction"] == "inbound" and row["event_source"] == "user" and row["event_type"] == "command" and row["content"] == "/help"
         for row in rows
     )
     assert any(
@@ -267,8 +258,7 @@ async def test_session_events_treat_unrecognized_slash_input_as_normal_message_t
         for row in rows
     )
     assert not any(
-        row["direction"] == "inbound" and row["event_type"] == "command" and row["content"] == "/unknown gesture"
-        for row in rows
+        row["direction"] == "inbound" and row["event_type"] == "command" and row["content"] == "/unknown gesture" for row in rows
     )
     assert any(
         row["direction"] == "outbound"

--- a/tests/functional/test_explore_simulation_flow.py
+++ b/tests/functional/test_explore_simulation_flow.py
@@ -81,9 +81,7 @@ async def test_basic_ungated_simulation_10_turns(patch_llm_client, _isolate_db_s
         assert len(session._events) > prev_event_count, f"Turn {turn_num}: _events should grow after each step"
 
         # Turn count should increment
-        assert session.turns == turn_num + 1, (
-            f"Turn {turn_num}: session.turns should be {turn_num + 1} (got {session.turns})"
-        )
+        assert session.turns == turn_num + 1, f"Turn {turn_num}: session.turns should be {turn_num + 1} (got {session.turns})"
 
     # Verify final turn count: 1 (ENTER) + 10 user turns
     assert session.turns == 11, f"Should have completed 11 turns (got {session.turns})"

--- a/tests/functional/test_foresight_simulation_flow.py
+++ b/tests/functional/test_foresight_simulation_flow.py
@@ -3,7 +3,7 @@
 This test suite validates the foresight game's unique mechanics:
 1. Prediction parsing - validator allows predictions in user input
 2. Prediction ignoring - updater processes only the action, not the prediction
-3. Completion notes - /complete triggers a question, next input is collected
+3. /predict-next records repeatable predictions without ending the game
 4. Multi-turn simulation flow with prediction-containing inputs
 
 Tests use mocked LLMs to avoid external API dependencies.
@@ -108,13 +108,9 @@ async def test_foresight_simulation_10_turns(patch_llm_client, _isolate_db_state
         events = await session.step_async(user_input)
 
         ai_events = [e for e in events if e.get("type") == "ai"]
-        assert len(ai_events) > 0, (
-            f"Turn {turn_num}: Expected AI response event (validator should accept prediction syntax)"
-        )
+        assert len(ai_events) > 0, f"Turn {turn_num}: Expected AI response event (validator should accept prediction syntax)"
 
-        assert "predict" not in ai_events[0]["content"].lower(), (
-            f"Turn {turn_num}: Updater response should not acknowledge predictions"
-        )
+        assert "predict" not in ai_events[0]["content"].lower(), f"Turn {turn_num}: Updater response should not acknowledge predictions"
 
         assert session.turns == turns_after_enter + turn_num, (
             f"Turn {turn_num}: turns should be {turns_after_enter + turn_num} (got {session.turns})"
@@ -124,62 +120,8 @@ async def test_foresight_simulation_10_turns(patch_llm_client, _isolate_db_state
     assert not session.exited, "Session should stay open until the next input observes the stopping condition"
 
 
-async def test_foresight_complete_command(patch_llm_client, _isolate_db_state, async_mongo_provider):
-    """Test /complete command triggers completion-notes question."""
-    session = await SessionManager.create_async(
-        game="foresight",
-        provider=async_mongo_provider,
-        pc_choice="human-normative",
-        npc_choice="flatworm",
-        player_id=str(TEST_PLAYER_ID),
-    )
-
-    await session.step_async("")
-    await session.step_async("I wave my hand")
-    await session.step_async("I look around")
-
-    complete_events = await session.step_async("/complete")
-
-    # /complete should yield an info event asking for notes
-    info_events = [e for e in complete_events if e.get("type") == "info"]
-    assert len(info_events) > 0, "Expected an info event asking for completion notes"
-    assert "prediction" in info_events[0]["content"].lower() or "notes" in info_events[0]["content"].lower(), (
-        "Completion question should ask about predictions or notes"
-    )
-
-    # Session should NOT be exited yet — waiting for the answer
-    assert not session.exited, "Session should not exit until completion notes are provided"
-
-
-async def test_foresight_completion_notes_collected(patch_llm_client, _isolate_db_state, async_mongo_provider):
-    """Test that the answer after /complete is collected and game exits."""
-    session = await SessionManager.create_async(
-        game="foresight",
-        provider=async_mongo_provider,
-        pc_choice="human-normative",
-        npc_choice="flatworm",
-        player_id=str(TEST_PLAYER_ID),
-    )
-
-    await session.step_async("")
-    await session.step_async("I wave my hand")
-    await session.step_async("/complete")
-
-    # Provide the completion notes
-    notes_events = await session.step_async("My notes about my predictions.")
-
-    info_events = [e for e in notes_events if e.get("type") == "info"]
-    assert len(info_events) > 0, "Expected confirmation info event after notes submitted"
-
-    # Game should exit after notes collected
-    assert session.exited, "Session should be exited after completion notes provided"
-    assert session.game.completion_notes == "My notes about my predictions."
-
-
-async def test_foresight_complete_command_accepts_inline_notes(
-    patch_llm_client, _isolate_db_state, async_mongo_provider
-):
-    """Inline notes after /complete should finish the game immediately."""
+async def test_foresight_predict_next_command(patch_llm_client, _isolate_db_state, async_mongo_provider):
+    """Test /predict-next prompts for a prediction without ending the game."""
     session = await SessionManager.create_async(
         game="foresight",
         provider=async_mongo_provider,
@@ -191,12 +133,38 @@ async def test_foresight_complete_command_accepts_inline_notes(
     await session.step_async("")
     await session.step_async("I wave my hand")
 
-    complete_events = await session.step_async("/complete The person wants to make friends.")
+    predict_events = await session.step_async("/predict-next")
 
-    info_events = [e for e in complete_events if e.get("type") == "info"]
-    assert len(info_events) > 0, "Expected completion confirmation info event"
-    assert session.exited, "Session should exit when /complete includes inline notes"
-    assert session.game.completion_notes == "The person wants to make friends."
+    info_events = [e for e in predict_events if e.get("type") == "info"]
+    assert len(info_events) > 0, "Expected an info event asking for a prediction"
+    assert "predict" in info_events[0]["content"].lower()
+    assert not session.exited, "Session should remain active after /predict-next"
+
+
+async def test_foresight_predict_next_answer_is_repeatable(patch_llm_client, _isolate_db_state, async_mongo_provider):
+    """Predictions collected via /predict-next should be stored and repeatable."""
+    session = await SessionManager.create_async(
+        game="foresight",
+        provider=async_mongo_provider,
+        pc_choice="human-normative",
+        npc_choice="flatworm",
+        player_id=str(TEST_PLAYER_ID),
+    )
+
+    await session.step_async("")
+    await session.step_async("/predict-next")
+    first_events = await session.step_async("The flatworm will retreat into the shade.")
+    assert any(e["type"] == "info" for e in first_events), "Expected prediction confirmation"
+    assert session.game.predictions == ["The flatworm will retreat into the shade."]
+    assert not session.exited
+
+    second_events = await session.step_async("/predict-next It will move toward the food.")
+    assert any(e["type"] == "info" for e in second_events), "Expected inline prediction confirmation"
+    assert session.game.predictions == [
+        "The flatworm will retreat into the shade.",
+        "It will move toward the food.",
+    ]
+    assert not session.exited
 
 
 async def test_foresight_run_save(patch_llm_client, _isolate_db_state, async_mongo_provider):
@@ -217,5 +185,4 @@ async def test_foresight_run_save(patch_llm_client, _isolate_db_state, async_mon
     await session.exit_async("test complete")
     assert session.exited, "Session should be exited after exit()"
 
-    # save() is called by exit(); calling again is a no-op (idempotent)
     session.save()

--- a/tests/functional/test_goal_horizon_simulation_flow.py
+++ b/tests/functional/test_goal_horizon_simulation_flow.py
@@ -2,8 +2,9 @@
 
 This test suite validates the goal-horizon game's mechanics:
 1. Consent-required player access
-2. Standard enter/turn/exit flow
-3. Session persistence
+2. Standard enter/turn flow
+3. /predict-capabilities ends the game with a final answer
+4. Session persistence
 
 Tests use mocked LLMs to avoid external API dependencies.
 """
@@ -19,7 +20,6 @@ from dcs_simulation_engine.dal.mongo.const import (
 
 pytestmark = [pytest.mark.functional, pytest.mark.anyio]
 
-# Test player ID for goal-horizon tests (requires consent)
 TEST_PLAYER_ID = ObjectId()
 
 
@@ -68,6 +68,27 @@ async def test_goal_horizon_enter_step(patch_llm_client, _isolate_db_state, asyn
     assert session._events is not None, "Session events should exist after step"
 
 
+async def test_goal_horizon_predict_capabilities_completion(patch_llm_client, _isolate_db_state, async_mongo_provider):
+    """Test /predict-capabilities collects a final answer and exits."""
+    session = await SessionManager.create_async(
+        game="Goal Horizon",
+        provider=async_mongo_provider,
+        pc_choice="human-normative",
+        npc_choice="flatworm",
+        player_id=str(TEST_PLAYER_ID),
+    )
+
+    await session.step_async("")
+    command_events = await session.step_async("/predict-capabilities")
+    assert any(e["type"] == "info" for e in command_events), "Expected info prompt from /predict-capabilities"
+    assert not session.exited
+
+    answer_events = await session.step_async("It seems limited to local sensing and cautious movement.")
+    assert any(e["type"] == "info" for e in answer_events), "Expected completion confirmation"
+    assert session.exited, "Session should exit after the prediction is submitted"
+    assert session.game.capability_prediction == "It seems limited to local sensing and cautious movement."
+
+
 async def test_goal_horizon_exit_and_save(patch_llm_client, _isolate_db_state, async_mongo_provider):
     """Test goal-horizon game sessions can be exited and saved."""
     session = await SessionManager.create_async(
@@ -84,5 +105,4 @@ async def test_goal_horizon_exit_and_save(patch_llm_client, _isolate_db_state, a
     assert session.exited, "Session should be exited after exit()"
     assert session.exit_reason == "test complete"
 
-    # save() is called internally by exit(); calling again is a no-op
     session.save()

--- a/tests/functional/test_infer_intent_simulation_flow.py
+++ b/tests/functional/test_infer_intent_simulation_flow.py
@@ -2,8 +2,8 @@
 
 This test suite validates the infer-intent game's unique mechanics:
 1. PC is fixed to human-normative, NPC excludes human-normative
-2. /guess command triggers a 2-step completion form (goal inference + feedback)
-3. /help and /abilities command handlers
+2. /predict-intent command triggers a 2-step completion form (goal inference + feedback)
+3. /help command handler
 4. Goal-aligned NPC responses
 5. Completion form collects goal_inference and other_feedback, then exits
 
@@ -21,7 +21,6 @@ from dcs_simulation_engine.dal.mongo.const import (
 
 pytestmark = [pytest.mark.functional, pytest.mark.anyio]
 
-# Test player ID for infer-intent tests (requires consent)
 TEST_PLAYER_ID = ObjectId()
 
 
@@ -81,8 +80,8 @@ async def test_infer_intent_enter_welcome_message(patch_llm_client, _isolate_db_
     assert not session.exited, "Session should not be exited after ENTER"
 
 
-async def test_infer_intent_guess_command(patch_llm_client, _isolate_db_state, async_mongo_provider):
-    """Test /guess command triggers goal-inference question."""
+async def test_infer_intent_predict_intent_command(patch_llm_client, _isolate_db_state, async_mongo_provider):
+    """Test /predict-intent command triggers goal-inference question."""
     session = await SessionManager.create_async(
         game="Infer Intent",
         provider=async_mongo_provider,
@@ -94,13 +93,11 @@ async def test_infer_intent_guess_command(patch_llm_client, _isolate_db_state, a
     await session.step_async("")
     await session.step_async("I look around")
 
-    guess_events = await session.step_async("/guess")
+    guess_events = await session.step_async("/predict-intent")
 
     info_events = [e for e in guess_events if e.get("type") == "info"]
     assert len(info_events) > 0, "Expected info event asking for goal inference"
-
-    # Session should NOT exit yet — awaiting goal inference answer
-    assert not session.exited, "Session should not exit after /guess"
+    assert not session.exited, "Session should not exit after /predict-intent"
 
 
 async def test_infer_intent_help_command(patch_llm_client, _isolate_db_state, async_mongo_provider):
@@ -120,25 +117,6 @@ async def test_infer_intent_help_command(patch_llm_client, _isolate_db_state, as
     info_events = [e for e in help_events if e.get("type") == "info"]
     assert len(info_events) > 0, "Expected info event from /help command"
     assert not session.exited, "Session should remain active after /help"
-
-
-async def test_infer_intent_abilities_command(patch_llm_client, _isolate_db_state, async_mongo_provider):
-    """Test /abilities command returns character abilities."""
-    session = await SessionManager.create_async(
-        game="Infer Intent",
-        provider=async_mongo_provider,
-        pc_choice="human-normative",
-        npc_choice="flatworm",
-        player_id=str(TEST_PLAYER_ID),
-    )
-
-    await session.step_async("")
-
-    abilities_events = await session.step_async("/abilities")
-
-    info_events = [e for e in abilities_events if e.get("type") == "info"]
-    assert len(info_events) > 0, "Expected info event from /abilities command"
-    assert not session.exited, "Session should remain active after /abilities"
 
 
 async def test_infer_intent_simulation_turns(patch_llm_client, _isolate_db_state, async_mongo_provider):
@@ -170,7 +148,7 @@ async def test_infer_intent_simulation_turns(patch_llm_client, _isolate_db_state
 
 
 async def test_infer_intent_completion_form(patch_llm_client, _isolate_db_state, async_mongo_provider):
-    """Test 2-step completion form: /guess -> goal inference -> other feedback -> exit."""
+    """Test 2-step completion form: /predict-intent -> goal inference -> other feedback -> exit."""
     session = await SessionManager.create_async(
         game="Infer Intent",
         provider=async_mongo_provider,
@@ -182,18 +160,15 @@ async def test_infer_intent_completion_form(patch_llm_client, _isolate_db_state,
     await session.step_async("")
     await session.step_async("I observe the creature")
 
-    # Step 1: /guess triggers goal inference question
-    guess_events = await session.step_async("/guess")
-    assert any(e["type"] == "info" for e in guess_events), "Expected info event from /guess"
+    guess_events = await session.step_async("/predict-intent")
+    assert any(e["type"] == "info" for e in guess_events), "Expected info event from /predict-intent"
     assert not session.exited
 
-    # Step 2: provide goal inference — triggers other feedback question
     inference_events = await session.step_async("The creature is trying to find food.")
     assert any(e["type"] == "info" for e in inference_events), "Expected follow-up question"
     assert not session.exited, "Session should not exit after first answer"
     assert session.game.goal_inference == "The creature is trying to find food."
 
-    # Step 3: provide other feedback — exits without inline scoring
     feedback_events = await session.step_async("Interesting behavior overall.")
     assert any(e["type"] == "info" for e in feedback_events), "Expected completion confirmation"
     assert session.exited, "Session should exit after second answer"
@@ -218,5 +193,4 @@ async def test_infer_intent_exit_and_save(patch_llm_client, _isolate_db_state, a
     await session.exit_async("test complete")
     assert session.exited, "Session should be exited after exit()"
 
-    # save() is called internally by exit(); calling again is a no-op
     session.save()

--- a/tests/infra/test_remote.py
+++ b/tests/infra/test_remote.py
@@ -169,18 +169,10 @@ def test_deploy_remote_experiment_generates_configs_and_commands(
     assert "issued-secret-key" not in result.save_command
     assert len(deploy_calls) == 3
 
-    api_fly = (artifacts_root / "deployments" / "usability-ca" / "dcs-usability-ca-api.fly.toml").read_text(
-        encoding="utf-8"
-    )
-    ui_fly = (artifacts_root / "deployments" / "usability-ca" / "dcs-usability-ca-ui.fly.toml").read_text(
-        encoding="utf-8"
-    )
-    db_fly = (artifacts_root / "deployments" / "usability-ca" / "dcs-usability-ca-db.fly.toml").read_text(
-        encoding="utf-8"
-    )
-    copied_experiment = (
-        artifacts_root / "deployments" / "usability-ca" / "experiments" / "usability-ca.yaml"
-    ).read_text(encoding="utf-8")
+    api_fly = (artifacts_root / "deployments" / "usability-ca" / "dcs-usability-ca-api.fly.toml").read_text(encoding="utf-8")
+    ui_fly = (artifacts_root / "deployments" / "usability-ca" / "dcs-usability-ca-ui.fly.toml").read_text(encoding="utf-8")
+    db_fly = (artifacts_root / "deployments" / "usability-ca" / "dcs-usability-ca-db.fly.toml").read_text(encoding="utf-8")
+    copied_experiment = (artifacts_root / "deployments" / "usability-ca" / "experiments" / "usability-ca.yaml").read_text(encoding="utf-8")
 
     assert 'dockerfile = "../../docker/api.dockerfile"' in api_fly
     assert "--host 0.0.0.0 --port 8000" in api_fly

--- a/tests/manual/load_test.py
+++ b/tests/manual/load_test.py
@@ -39,9 +39,7 @@ from websockets.asyncio.client import connect
 try:
     import pandas as pd
 except ModuleNotFoundError as exc:
-    raise SystemExit(
-        "Missing dependency: pandas. Install pandas to run load_test.py with dataframe export support."
-    ) from exc
+    raise SystemExit("Missing dependency: pandas. Install pandas to run load_test.py with dataframe export support.") from exc
 
 
 @dataclass
@@ -154,8 +152,7 @@ def _find_playable_setup(
         npcs = setup.npcs
         if not setup.can_start or not pcs or not npcs:
             diagnostics.append(
-                f"{game_name}: can_start={setup.can_start} "
-                f"denial_reason={setup.denial_reason} pcs={len(pcs)} npcs={len(npcs)}"
+                f"{game_name}: can_start={setup.can_start} denial_reason={setup.denial_reason} pcs={len(pcs)} npcs={len(npcs)}"
             )
             continue
         return game_name, random.choice(pcs).hid, random.choice(npcs).hid
@@ -372,9 +369,7 @@ def run_load_test(
     ctx = mp.get_context("spawn")
     results: list[ClientResult] = []
     with concurrent.futures.ProcessPoolExecutor(max_workers=n_clients, mp_context=ctx) as pool:
-        futures = [
-            pool.submit(_run_client_process, i, base_url, n_games, n_turns, forced_game) for i in range(n_clients)
-        ]
+        futures = [pool.submit(_run_client_process, i, base_url, n_games, n_turns, forced_game) for i in range(n_clients)]
         for fut in concurrent.futures.as_completed(futures):
             results.append(fut.result())
     return sorted(results, key=lambda r: r.client_id)
@@ -400,12 +395,7 @@ def _print_summary(results: list[ClientResult], elapsed_s: float) -> None:
     print(f"Total game failures: {len(failed)}")
 
     if durations_ms:
-        print(
-            "Per-game duration (ms): "
-            f"min={min(durations_ms):.3f} "
-            f"mean={statistics.fmean(durations_ms):.3f} "
-            f"max={max(durations_ms):.3f}"
-        )
+        print(f"Per-game duration (ms): min={min(durations_ms):.3f} mean={statistics.fmean(durations_ms):.3f} max={max(durations_ms):.3f}")
     else:
         print("Per-game duration (ms): n/a")
 
@@ -443,11 +433,7 @@ def _print_summary(results: list[ClientResult], elapsed_s: float) -> None:
 
     print("\nGames per client:")
     for client in sorted(results, key=lambda r: r.client_id):
-        print(
-            f"  client {client.client_id:>3}: "
-            f"completed={client.completed_games}/{client.attempted_games} "
-            f"errors={len(client.errors)}"
-        )
+        print(f"  client {client.client_id:>3}: completed={client.completed_games}/{client.attempted_games} errors={len(client.errors)}")
 
     if failed:
         print("\nErrors:")

--- a/ui/src/routes/play/$sessionId.tsx
+++ b/ui/src/routes/play/$sessionId.tsx
@@ -41,16 +41,24 @@ const GAME_COMMANDS: Record<string, CommandSuggestion[]> = {
   ],
   goalhorizon: [
     { command: '/help', description: 'Show the game instructions again.' },
-    { command: '/abilities', description: 'Show your character and NPC abilities.' },
+    {
+      command: '/predict-capabilities',
+      description: "Submit your read on the character's limits and end the game.",
+    },
   ],
   inferintent: [
     { command: '/help', description: 'Show the game instructions again.' },
-    { command: '/abilities', description: 'Show your character abilities.' },
-    { command: '/guess', description: 'Submit your intent inference and finish the game.' },
+    {
+      command: '/predict-intent',
+      description: "Submit your read on the character's intent and end the game.",
+    },
   ],
   foresight: [
     { command: '/help', description: 'Show the game instructions again.' },
-    { command: '/complete', description: 'Finish the game and submit your prediction notes.' },
+    {
+      command: '/predict-next',
+      description: 'Record what you think the system character will do next.',
+    },
   ],
 }
 


### PR DESCRIPTION
This change renames the player-facing prediction commands for the study games, updates the Infer Intent evaluation flow to match the new command name, and trims the hosted Fly defaults for lower-cost usability and free-play deployments.

It also adds zsh autosuggestions in the devcontainer, surfaces the UI link in `dcs remote deploy`, bumps Ruff line length to 140, and refreshes the related docs, configs, and tests to match.

Key changes:
- Replace the old game commands with `/predict-next`, `/predict-intent`, and `/predict-capabilities`
- Rework Foresight and Goal Horizon to use the new prediction flows and update the in-game instructions/UI command suggestions accordingly
- Update Infer Intent evaluation reconstruction to look for `predict-intent` in persisted session events and refresh the related API, CLI, and manual tests
- Switch the checked-in Fly deployment configs/docs to `iad` and reduce API/DB VM memory defaults from `1gb` to `512mb`
- Print a direct UI browser link at the end of `dcs remote deploy`
- Add `zsh-autosuggestions` to the devcontainer shell setup and increase Ruff line length to 140, with the expected formatting churn in touched files

Why:
- Make the gameplay commands clearer and more aligned with each game's objective
- Keep post-game evaluation behavior consistent with the renamed commands
- Lower hosted deployment cost and make remote deploy output easier to use
- Improve day-to-day devcontainer shell ergonomics