### PR TITLE
Add codebase coverage to CI workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,8 @@ ui/openapi.snapshot.json
 runs/
 deployments/
 results/
+
+# coverage reports
+htmlcov/
+.coverage
+coverage.xml

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # .PHONY tells make that these aren't real files — they're just task names.
 # Without this, make might skip a task if a file with the same name exists.
-.PHONY: ci docs fmt lint lint-fix test
+.PHONY: ci coverage docs fmt lint lint-fix test test-fast
 
 # Run all linting checks (on the dcs_simulation_engine/ package here).
 lint:
@@ -16,9 +16,18 @@ fmt:
 	uv run ruff format && uv run ruff check --select I --fix
 	cd ui && bun format
 
-# Run test suite quietly
+# Run test suite with line+branch coverage (fails if under 85% per toml)
 test:
 	uv run pytest
+
+# Run test suite without coverage (faster iteration)
+test-fast:
+	uv run pytest --no-cov
+
+# Run coverage report without enforcing the fail-under threshold
+# HTML report written to htmlcov/index.html
+coverage:
+	uv run pytest --cov-fail-under=0 --cov-report=html
 
 # Build documentation (MkDocs in this example).
 docs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,9 +94,12 @@ Issues = "https://github.com/diverse-cognitive-systems-group/dcs-simulation-engi
 [tool.pytest.ini_options]
 addopts = [
   "--cache-clear",
+  "--cov=dcs_simulation_engine",
   "--cov-report=term",
-  "--numprocesses=auto", # multiprocessing
   "--cov-report=xml",
+  "--cov-branch",
+  "--cov-fail-under=85",
+  "--numprocesses=auto", # multiprocessing
   "--durations=0",
   "--verbose",
   # "-x" # stop tests after first failure

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,11 +95,12 @@ Issues = "https://github.com/diverse-cognitive-systems-group/dcs-simulation-engi
 addopts = [
   "--cache-clear",
   "--cov=dcs_simulation_engine",
+  "--cov=dcs_utils",
   "--cov-report=term",
   "--cov-report=xml",
   "--cov-branch",
-  "--cov-fail-under=85",
-  "--numprocesses=auto", # multiprocessing
+  "--cov-fail-under=65",
+  "--numprocesses=auto",         # multiprocessing
   "--durations=0",
   "--verbose",
   # "-x" # stop tests after first failure
@@ -113,6 +114,9 @@ markers = [
   "infra: remote infrastructure tests",
 ]
 
+[tool.coverage.run]
+omit = ["dcs_utils/manual/*"]
+
 [tool.isort]
 combine_as_imports = true
 line_length = 60
@@ -122,7 +126,7 @@ profile = "black"
 [tool.ruff]
 exclude = [
   "dcs_utils/*", # dcs_utils folder
-  "**/*.ipynb", # all notebooks
+  "**/*.ipynb",  # all notebooks
 ]
 line-length = 140
 src = ["dcs_simulation_engine", "tests"]


### PR DESCRIPTION
# Overview
Test coverage isn’t a guarantee of good/thorough testing, but it helps identify untested areas and maintain a baseline level of confidence. 

Ergo, I like having coverage targets in place and before release they should be >95% generally speaking.

## Changes

Adds code coverage target and updates Makefile to include coverage on `make test` calls.

To skip coverage use `make test-fast`

To run coverage and see html report run make coverage