### PR TITLE
Trigger refactor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 * Smaller codebases are better than larger codebases.
 * Removing code is better than adding code if we can preserve functionality.
 * Prefer adding less code if it doesn't impact clarity or maintainability.
+* Do not change orval generated code manually
 
 ### Principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,6 @@
 * Smaller codebases are better than larger codebases.
 * Removing code is better than adding code if we can preserve functionality.
 * Prefer adding less code if it doesn't impact clarity or maintainability.
-* Do not change orval generated code manually
 
 ### Principles
 
@@ -15,6 +14,11 @@
 * Strict API/UI separation — backend must not control or depend on UI
 * GUI is a client — no business logic in the frontend
 * DAL is isolated — database should be easily swappable
+
+### UI Guidelines
+
+* Do not change orval generated code manually
+* Use bun instead of npm
 
 ### Python Style
 

--- a/dcs_simulation_engine/api/models.py
+++ b/dcs_simulation_engine/api/models.py
@@ -13,6 +13,12 @@ EventType = Literal["ai", "info", "error", "warning"]
 SetupDenialReason = Literal["no_valid_pc", "no_valid_npc"]
 AssignmentStatus = Literal["assigned", "in_progress", "completed", "interrupted"]
 NextAssignmentMode = Literal["locked", "choice", "blocked", "none"]
+FormTriggerEvent = Literal[
+    "before_all_assignments",
+    "before_assignment",
+    "after_assignment",
+    "after_all_assignments",
+]
 
 
 class RegistrationRequest(BaseModel):
@@ -182,6 +188,22 @@ class NextAssignmentState(BaseModel):
     options: list["EligibleAssignmentOption"] = Field(default_factory=list)
 
 
+class FormTriggerResponse(BaseModel):
+    """Canonical form trigger returned by setup APIs."""
+
+    event: FormTriggerEvent
+    match: None = None
+
+
+class PendingFormGroupResponse(BaseModel):
+    """Actionable group of forms the participant must submit."""
+
+    group_id: str
+    trigger: FormTriggerResponse
+    forms: list[dict] = Field(default_factory=list)
+    assignment_id: str | None = None
+
+
 class ExperimentSetupResponse(BaseModel):
     """Setup payload for the experiment landing page."""
 
@@ -189,6 +211,7 @@ class ExperimentSetupResponse(BaseModel):
     description: str
     is_open: bool
     forms: list[dict] = Field(default_factory=list)
+    pending_form_groups: list[PendingFormGroupResponse] = Field(default_factory=list)
     progress: ExperimentProgressResponse
     current_assignment: ExperimentAssignmentSummary | None = None
     pending_post_play: bool = False
@@ -232,29 +255,25 @@ class SelectAssignmentRequest(BaseModel):
     npc_hid: str
 
 
-class ExperimentPlayerRequest(BaseModel):
-    """Entry-form payload for experiment registration."""
+class ExperimentFormSubmitRequest(BaseModel):
+    """Payload for submitting one pending experiment form group."""
 
+    group_id: str = Field(min_length=1)
     responses: dict[str, dict]
 
 
-class ExperimentPlayerResponse(BaseModel):
-    """Assignment response after an authenticated player submits before-play forms."""
+class ExperimentFormSubmitResponse(BaseModel):
+    """Response after storing one pending experiment form group."""
 
-    assignment: ExperimentAssignmentSummary | None = None
+    group_id: str
+    trigger: FormTriggerResponse
+    assignment_id: str | None = None
 
 
 class ExperimentSessionRequest(BaseModel):
     """Payload for creating a session from the current assignment."""
 
     source: str = Field(default="experiment", min_length=1)
-    assignment_id: str | None = None
-
-
-class ExperimentPostPlayRequest(BaseModel):
-    """Payload for storing experiment post-play form answers."""
-
-    responses: dict[str, dict]
     assignment_id: str | None = None
 
 

--- a/dcs_simulation_engine/api/routers/experiments.py
+++ b/dcs_simulation_engine/api/routers/experiments.py
@@ -14,15 +14,15 @@ from dcs_simulation_engine.api.models import (
     EligibleAssignmentOption,
     EligibleAssignmentOptionsResponse,
     ExperimentAssignmentSummary,
+    ExperimentFormSubmitRequest,
+    ExperimentFormSubmitResponse,
     ExperimentGameStatusResponse,
-    ExperimentPlayerRequest,
-    ExperimentPlayerResponse,
-    ExperimentPostPlayRequest,
     ExperimentProgressResponse,
     ExperimentSessionRequest,
     ExperimentSetupResponse,
     ExperimentStatusResponse,
     NextAssignmentState,
+    PendingFormGroupResponse,
     SelectAssignmentRequest,
 )
 from dcs_simulation_engine.core.experiment_manager import ExperimentManager
@@ -95,6 +95,15 @@ async def _eligible_assignment_options(provider, options) -> list[EligibleAssign
     return enriched
 
 
+def _pending_form_group_response(group) -> PendingFormGroupResponse:
+    return PendingFormGroupResponse(
+        group_id=group["group_id"],
+        trigger=group["trigger"],
+        forms=[form.model_dump(mode="json") for form in group.get("forms", [])],
+        assignment_id=group.get("assignment_id"),
+    )
+
+
 async def _next_assignment_state(
     provider,
     *,
@@ -129,7 +138,7 @@ async def _next_assignment_state(
     if not is_open:
         return NextAssignmentState(mode="none", reason="quota_closed")
     if not has_submitted_before_forms:
-        return NextAssignmentState(mode="blocked", reason="before_forms")
+        return NextAssignmentState(mode="blocked", reason="pending_forms")
     return NextAssignmentState(mode="none", reason="unavailable")
 
 
@@ -177,6 +186,7 @@ async def experiment_setup(experiment_name: str, request: Request) -> Experiment
     current_assignment = player_state["active_assignment"]
     pending_post_play_ids = set(player_state.get("pending_post_play_ids", []))
     pending_post_play = bool(pending_post_play_ids)
+    pending_form_groups = player_state.get("pending_form_groups", [])
     assignment_completed = bool(player_state["has_finished_experiment"])
     eligible_options = player_state.get("eligible_assignment_options", [])
 
@@ -194,6 +204,7 @@ async def experiment_setup(experiment_name: str, request: Request) -> Experiment
         description=config.description,
         is_open=is_open,
         forms=[form.model_dump(mode="json") for form in config.forms],
+        pending_form_groups=[_pending_form_group_response(group) for group in pending_form_groups],
         progress=_progress_response(progress),
         current_assignment=await _assignment_summary(
             provider,
@@ -226,13 +237,13 @@ async def experiment_setup(experiment_name: str, request: Request) -> Experiment
     )
 
 
-@router.post("/{experiment_name}/players", response_model=ExperimentPlayerResponse)
-async def register_experiment_player(
+@router.post("/{experiment_name}/forms/submit", response_model=ExperimentFormSubmitResponse)
+async def submit_experiment_form_group(
     experiment_name: str,
-    body: ExperimentPlayerRequest,
+    body: ExperimentFormSubmitRequest,
     request: Request,
-) -> ExperimentPlayerResponse:
-    """Store before-play experiment forms for the authenticated participant and generate an assignment."""
+) -> ExperimentFormSubmitResponse:
+    """Store responses for one pending experiment form group."""
     require_standard_mode_from_request(
         request,
         detail="Experiment endpoints are disabled when the server is running in free play mode.",
@@ -241,16 +252,21 @@ async def register_experiment_player(
     provider = get_provider_from_request(request)
     player = await require_player_async(provider=provider, api_key=api_key_from_request(request))
     try:
-        assignment = await ExperimentManager.submit_before_play_async(
+        group = await ExperimentManager.submit_form_group_async(
             provider=provider,
             experiment_name=experiment_name,
             player_id=player.id,
+            group_id=body.group_id,
             responses=body.responses,
         )
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
-    return ExperimentPlayerResponse(assignment=await _assignment_summary(provider, assignment))
+    return ExperimentFormSubmitResponse(
+        group_id=group["group_id"],
+        trigger=group["trigger"],
+        assignment_id=group.get("assignment_id"),
+    )
 
 
 @router.post("/{experiment_name}/sessions", response_model=CreateGameResponse)
@@ -290,35 +306,6 @@ async def create_experiment_session(
     )
 
 
-@router.post("/{experiment_name}/post-play", response_model=ExperimentAssignmentSummary)
-async def submit_experiment_post_play(
-    experiment_name: str,
-    body: ExperimentPostPlayRequest,
-    request: Request,
-) -> ExperimentAssignmentSummary:
-    """Store the experiment post-play form on one completed assignment."""
-    require_standard_mode_from_request(
-        request,
-        detail="Experiment endpoints are disabled when the server is running in free play mode.",
-    )
-    _require_allowed_experiment(experiment_name=experiment_name, request=request)
-    provider = get_provider_from_request(request)
-    player = await require_player_async(provider=provider, api_key=api_key_from_request(request))
-
-    try:
-        assignment = await ExperimentManager.store_post_play_async(
-            provider=provider,
-            experiment_name=experiment_name,
-            player_id=player.id,
-            responses=body.responses,
-            assignment_id=body.assignment_id,
-        )
-    except ValueError as exc:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
-
-    return await _assignment_summary(provider, assignment)
-
-
 @router.get("/{experiment_name}/progress", response_model=ExperimentProgressResponse)
 async def experiment_progress(experiment_name: str, request: Request) -> ExperimentProgressResponse:
     """Return the current finite progress for the usability experiment."""
@@ -349,12 +336,7 @@ async def get_eligible_options(experiment_name: str, request: Request) -> Eligib
         experiment_name=experiment_name,
         player=player,
     )
-    return EligibleAssignmentOptionsResponse(
-        options=[
-            option
-            for option in await _eligible_assignment_options(provider, options)
-        ]
-    )
+    return EligibleAssignmentOptionsResponse(options=[option for option in await _eligible_assignment_options(provider, options)])
 
 
 @router.post("/{experiment_name}/assignments/select", response_model=ExperimentAssignmentSummary)

--- a/dcs_simulation_engine/api/routers/play.py
+++ b/dcs_simulation_engine/api/routers/play.py
@@ -364,7 +364,7 @@ async def play_ws(websocket: WebSocket, session_id: str) -> None:
         pc = getattr(game, "_pc", None)
         npc = getattr(game, "_npc", None)
         game_config = SessionManager.get_game_config_cached(entry.game_name)
-        has_game_feedback = any(f.before_or_after == "after" for f in game_config.forms)
+        has_game_feedback = any(f.trigger.event == "after_assignment" for f in game_config.forms)
         meta_frame = WSSessionMetaFrame(
             session_id=session_id,
             pc_hid=getattr(pc, "hid", None),

--- a/dcs_simulation_engine/core/experiment_config.py
+++ b/dcs_simulation_engine/core/experiment_config.py
@@ -7,6 +7,7 @@ from typing import Any, Literal, Optional
 import yaml
 from dcs_simulation_engine.core.forms import (
     ExperimentForm,
+    FormTriggerEvent,
 )
 from dcs_simulation_engine.utils.serde import SerdeMixin
 from pydantic import (
@@ -132,9 +133,21 @@ class ExperimentConfig(SerdeMixin, BaseModel):
         """Canonical list of games included in the experiment assignment strategy."""
         return list(self.assignment_strategy.games or [])
 
-    def forms_for_phase(self, *, before_or_after: str) -> list[ExperimentForm]:
-        """Return forms matching one phase."""
-        return [form for form in self.forms if form.before_or_after == before_or_after]
+    def forms_for_trigger(self, *, event: FormTriggerEvent | str) -> list[ExperimentForm]:
+        """Return forms matching one registered trigger event."""
+        return [form for form in self.forms if form.trigger.event == event]
+
+    def form_groups_for_trigger(self, *, event: FormTriggerEvent | str) -> list[dict[str, Any]]:
+        """Return configured form groups for one trigger event."""
+        forms = self.forms_for_trigger(event=event)
+        if not forms:
+            return []
+        return [
+            {
+                "trigger": {"event": event, "match": None},
+                "forms": forms,
+            }
+        ]
 
     @classmethod
     def load(cls, path: str | Path) -> "ExperimentConfig":

--- a/dcs_simulation_engine/core/experiment_manager.py
+++ b/dcs_simulation_engine/core/experiment_manager.py
@@ -10,6 +10,7 @@ from dcs_simulation_engine.core.experiment_config import ExperimentConfig
 from dcs_simulation_engine.core.forms import (
     ExperimentForm,
     ExperimentFormQuestion,
+    FormTriggerEvent,
 )
 from dcs_simulation_engine.core.session_manager import SessionManager
 from dcs_simulation_engine.dal.base import (
@@ -128,30 +129,22 @@ class ExperimentManager:
     ) -> dict[str, Any]:
         """Return the assignment state visible to one authenticated player."""
         config = cls.get_experiment_config_cached(experiment_name)
-        before_form_names = {form.name for form in config.forms_for_phase(before_or_after="before")}
-        after_form_names = {form.name for form in config.forms_for_phase(before_or_after="after")}
-        player_forms = await maybe_await(provider.get_player_forms(player_id=player_id, experiment_name=experiment_name))
-        submitted_before_keys = set((player_forms.data if player_forms else {}).keys())
-        has_submitted_before_forms = not before_form_names or before_form_names.issubset(submitted_before_keys)
-
-        def _pending_post_play_items(assignments: list[AssignmentRecord]) -> list[AssignmentRecord]:
-            completed = [item for item in assignments if item.status == "completed"]
-            return [item for item in completed if not after_form_names.issubset(set(item.data.get(MongoColumns.FORM_RESPONSES, {}).keys()))]
-
         player_assignments = await maybe_await(provider.list_assignments(experiment_name=experiment_name, player_id=player_id))
         active_assignment = await maybe_await(provider.get_active_assignment(experiment_name=experiment_name, player_id=player_id))
-        pending_post_play_items = _pending_post_play_items(player_assignments)
-        pending_post_play = pending_post_play_items[-1] if pending_post_play_items else None
         completed_assignments = [item for item in player_assignments if item.status == "completed"]
         strategy = cls._strategy_for(config=config)
         has_finished_experiment = len(completed_assignments) >= strategy.max_assignments_per_player(config=config)
         eligible_assignment_options: list[dict[str, str]] = []
+        pending_form_groups = await cls.pending_form_groups_async(
+            provider=provider,
+            config=config,
+            player_id=player_id,
+            assignments=player_assignments,
+            active_assignment=active_assignment,
+            has_finished_experiment=has_finished_experiment,
+        )
 
-        if (
-            pending_post_play is None
-            and has_submitted_before_forms
-            and not has_finished_experiment
-        ):
+        if not cls._blocks_assignment_resolution(pending_form_groups) and not has_finished_experiment:
             player_record = await maybe_await(provider.get_player(player_id=player_id))
             if player_record is not None:
                 active_assignment, eligible_assignment_options = await cls.resolve_assignment_state_async(
@@ -162,8 +155,30 @@ class ExperimentManager:
                     active_assignment=active_assignment,
                 )
                 player_assignments = await maybe_await(provider.list_assignments(experiment_name=experiment_name, player_id=player_id))
-                pending_post_play_items = _pending_post_play_items(player_assignments)
-                pending_post_play = pending_post_play_items[-1] if pending_post_play_items else None
+                completed_assignments = [item for item in player_assignments if item.status == "completed"]
+                has_finished_experiment = len(completed_assignments) >= strategy.max_assignments_per_player(config=config)
+                pending_form_groups = await cls.pending_form_groups_async(
+                    provider=provider,
+                    config=config,
+                    player_id=player_id,
+                    assignments=player_assignments,
+                    active_assignment=active_assignment,
+                    has_finished_experiment=has_finished_experiment,
+                )
+
+        pending_post_play_items = [
+            assignment
+            for assignment in player_assignments
+            if any(
+                group["trigger"]["event"] == "after_assignment"
+                and group.get("assignment_id") == assignment.assignment_id
+                for group in pending_form_groups
+            )
+        ]
+        pending_post_play = pending_post_play_items[-1] if pending_post_play_items else None
+        has_submitted_before_forms = not any(
+            group["trigger"]["event"] == "before_all_assignments" for group in pending_form_groups
+        )
 
         return {
             "active_assignment": active_assignment,
@@ -172,8 +187,119 @@ class ExperimentManager:
             "has_finished_experiment": has_finished_experiment,
             "has_submitted_before_forms": has_submitted_before_forms,
             "eligible_assignment_options": eligible_assignment_options,
+            "pending_form_groups": pending_form_groups,
             "assignments": await maybe_await(provider.list_assignments(experiment_name=experiment_name, player_id=player_id)),
         }
+
+    @classmethod
+    async def pending_form_groups_async(
+        cls,
+        *,
+        provider: Any,
+        config: ExperimentConfig,
+        player_id: str,
+        assignments: list[AssignmentRecord] | None = None,
+        active_assignment: AssignmentRecord | None = None,
+        has_finished_experiment: bool | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return actionable form groups still required for a player."""
+        if assignments is None:
+            assignments = await maybe_await(provider.list_assignments(experiment_name=config.name, player_id=player_id))
+        if active_assignment is None:
+            active_assignment = await maybe_await(provider.get_active_assignment(experiment_name=config.name, player_id=player_id))
+        if has_finished_experiment is None:
+            strategy = cls._strategy_for(config=config)
+            completed_count = sum(1 for item in assignments if item.status == "completed")
+            has_finished_experiment = completed_count >= strategy.max_assignments_per_player(config=config)
+
+        groups: list[dict[str, Any]] = []
+        player_forms = await maybe_await(provider.get_player_forms(player_id=player_id, experiment_name=config.name))
+        submitted_player_form_names = set((player_forms.data if player_forms else {}).keys())
+        groups.extend(
+            cls._pending_player_form_group(
+                config=config,
+                event="before_all_assignments",
+                submitted_form_names=submitted_player_form_names,
+            )
+        )
+
+        for assignment in assignments:
+            if assignment.status in {"assigned", "interrupted"}:
+                groups.extend(cls._pending_assignment_form_group(config=config, event="before_assignment", assignment=assignment))
+            if assignment.status == "completed":
+                groups.extend(cls._pending_assignment_form_group(config=config, event="after_assignment", assignment=assignment))
+
+        if has_finished_experiment:
+            groups.extend(
+                cls._pending_player_form_group(
+                    config=config,
+                    event="after_all_assignments",
+                    submitted_form_names=submitted_player_form_names,
+                )
+            )
+
+        return groups
+
+    @classmethod
+    def _pending_player_form_group(
+        cls,
+        *,
+        config: ExperimentConfig,
+        event: FormTriggerEvent,
+        submitted_form_names: set[str],
+    ) -> list[dict[str, Any]]:
+        forms = config.forms_for_trigger(event=event)
+        if not forms:
+            return []
+        required_names = {form.name for form in forms}
+        if required_names.issubset(submitted_form_names):
+            return []
+        return [
+            {
+                "group_id": event,
+                "trigger": {"event": event, "match": None},
+                "forms": forms,
+            }
+        ]
+
+    @classmethod
+    def _pending_assignment_form_group(
+        cls,
+        *,
+        config: ExperimentConfig,
+        event: FormTriggerEvent,
+        assignment: AssignmentRecord,
+    ) -> list[dict[str, Any]]:
+        forms = config.forms_for_trigger(event=event)
+        if not forms:
+            return []
+        submitted = set(assignment.data.get(MongoColumns.FORM_RESPONSES, {}).keys())
+        required_names = {form.name for form in forms}
+        if required_names.issubset(submitted):
+            return []
+        return [
+            {
+                "group_id": f"{event}:{assignment.assignment_id}",
+                "trigger": {"event": event, "match": None},
+                "assignment_id": assignment.assignment_id,
+                "forms": forms,
+            }
+        ]
+
+    @classmethod
+    def _blocks_assignment_resolution(cls, pending_form_groups: list[dict[str, Any]]) -> bool:
+        blocking_events = {"before_all_assignments", "after_assignment", "after_all_assignments"}
+        return any(group["trigger"]["event"] in blocking_events for group in pending_form_groups)
+
+    @classmethod
+    def _blocks_assignment_start(cls, *, pending_form_groups: list[dict[str, Any]], assignment_id: str) -> bool:
+        for group in pending_form_groups:
+            event = group["trigger"]["event"]
+            if event in {"before_all_assignments", "after_assignment", "after_all_assignments"}:
+                return True
+            if event == "before_assignment" and group.get("assignment_id") == assignment_id:
+                return True
+        return False
 
     @classmethod
     async def resolve_assignment_state_async(
@@ -191,6 +317,15 @@ class ExperimentManager:
         assignments = player_assignments
         if assignments is None:
             assignments = await maybe_await(provider.list_assignments(experiment_name=config.name, player_id=player.id))
+        pending_groups = await cls.pending_form_groups_async(
+            provider=provider,
+            config=config,
+            player_id=player.id,
+            assignments=assignments,
+            active_assignment=active_assignment,
+        )
+        if cls._blocks_assignment_resolution(pending_groups):
+            return None, []
         current = cls._current_assignment_from_policy(
             config=config,
             assignments=assignments,
@@ -326,88 +461,49 @@ class ExperimentManager:
         return assignment_doc
 
     @classmethod
-    async def _has_submitted_before_forms_async(
-        cls,
-        *,
-        provider: Any,
-        config: ExperimentConfig,
-        player_id: str,
-    ) -> bool:
-        before_form_names = {form.name for form in config.forms_for_phase(before_or_after="before")}
-        player_forms = await maybe_await(provider.get_player_forms(player_id=player_id, experiment_name=config.name))
-        submitted_before_keys = set((player_forms.data if player_forms else {}).keys())
-        return not before_form_names or before_form_names.issubset(submitted_before_keys)
-
-    @classmethod
-    async def _pending_post_play_assignment_async(
-        cls,
-        *,
-        config: ExperimentConfig,
-        player_assignments: list[AssignmentRecord],
-    ) -> AssignmentRecord | None:
-        completed_assignments = [item for item in player_assignments if item.status == "completed"]
-        after_form_names = {form.name for form in config.forms_for_phase(before_or_after="after")}
-        return next(
-            (
-                item
-                for item in reversed(completed_assignments)
-                if not after_form_names.issubset(set(item.data.get(MongoColumns.FORM_RESPONSES, {}).keys()))
-            ),
-            None,
-        )
-
-    @classmethod
-    async def _player_can_receive_assignment_options_async(
-        cls,
-        *,
-        provider: Any,
-        config: ExperimentConfig,
-        player: PlayerRecord,
-    ) -> bool:
-        player_assignments = await maybe_await(provider.list_assignments(experiment_name=config.name, player_id=player.id))
-        if await cls._pending_post_play_assignment_async(config=config, player_assignments=player_assignments) is not None:
-            return False
-        if not await cls._has_submitted_before_forms_async(provider=provider, config=config, player_id=player.id):
-            return False
-        strategy = cls._strategy_for(config=config)
-        completed_count = sum(1 for item in player_assignments if item.status == "completed")
-        return completed_count < strategy.max_assignments_per_player(config=config)
-
-    @classmethod
-    async def submit_before_play_async(
+    async def submit_form_group_async(
         cls,
         *,
         provider: Any,
         experiment_name: str,
         player_id: str,
+        group_id: str,
         responses: dict[str, Any],
-    ) -> AssignmentRecord | None:
-        """Store before-play form answers for an authenticated player and return their assignment."""
+    ) -> dict[str, Any]:
+        """Store responses for one currently pending form group."""
         config = cls.get_experiment_config_cached(experiment_name)
-
-        player_record = await maybe_await(provider.get_player(player_id=player_id))
-        if player_record is None:
-            raise ValueError("Authenticated player could not be loaded.")
-
-        progress = await cls.compute_progress_async(provider=provider, experiment_name=config.name)
-        if progress["is_complete"]:
-            raise ValueError("This experiment is no longer accepting new participants.")
-
-        before_forms = config.forms_for_phase(before_or_after="before")
-        normalized_before_forms = cls.normalize_form_submissions(forms=before_forms, responses=responses)
-        await cls.ensure_experiment_async(provider=provider, experiment_name=config.name)
-        await cls.store_player_form_payloads_async(
+        pending_groups = await cls.pending_form_groups_async(
             provider=provider,
+            config=config,
             player_id=player_id,
-            experiment_name=config.name,
-            forms_payload=normalized_before_forms,
         )
-        assignment, _options = await cls.resolve_assignment_state_async(
+        group = next((item for item in pending_groups if item["group_id"] == group_id), None)
+        if group is None:
+            raise ValueError("No pending form group matches the submitted group_id.")
+
+        forms = list(group["forms"])
+        normalized = cls.normalize_form_submissions(forms=forms, responses=responses)
+        event = group["trigger"]["event"]
+        if event in {"before_all_assignments", "after_all_assignments"}:
+            await cls.store_player_form_payloads_async(
+                provider=provider,
+                player_id=player_id,
+                experiment_name=config.name,
+                forms_payload=normalized,
+            )
+            return group
+
+        assignment_id = group.get("assignment_id")
+        if not assignment_id:
+            raise ValueError("Assignment-scoped form group is missing assignment_id.")
+        updated = await cls.store_form_payloads_async(
             provider=provider,
-            experiment_name=config.name,
-            player=player_record,
+            assignment_id=assignment_id,
+            forms_payload=normalized,
         )
-        return assignment
+        if updated is None:
+            raise ValueError("Failed to store the form response.")
+        return group
 
     @classmethod
     async def get_or_create_assignment_async(
@@ -454,6 +550,17 @@ class ExperimentManager:
             raise ValueError("No matching assignment is available for this player.")
         if assignment.status == "completed":
             raise ValueError("Completed assignments cannot be resumed.")
+        config = cls.get_experiment_config_cached(experiment_name)
+        assignments = await maybe_await(provider.list_assignments(experiment_name=config.name, player_id=player.id))
+        pending_groups = await cls.pending_form_groups_async(
+            provider=provider,
+            config=config,
+            player_id=player.id,
+            assignments=assignments,
+            active_assignment=assignment,
+        )
+        if cls._blocks_assignment_start(pending_form_groups=pending_groups, assignment_id=assignment.assignment_id):
+            raise ValueError("Required form responses must be submitted before starting this assignment.")
 
         if assignment.status == "in_progress":
             # Check whether the existing session is still resumable before
@@ -535,49 +642,6 @@ class ExperimentManager:
         if status == "completed":
             await cls.ensure_experiment_async(provider=provider, experiment_name=experiment_name)
         return updated
-
-    @classmethod
-    async def store_post_play_async(
-        cls,
-        *,
-        provider: Any,
-        experiment_name: str,
-        player_id: str,
-        responses: dict[str, Any],
-        assignment_id: str | None = None,
-    ) -> AssignmentRecord:
-        """Store all after-play forms on one completed assignment."""
-        config = cls.get_experiment_config_cached(experiment_name)
-        after_forms = config.forms_for_phase(before_or_after="after")
-        if assignment_id is not None:
-            assignment = await cls.get_assignment_for_player_async(
-                provider=provider,
-                experiment_name=config.name,
-                player_id=player_id,
-                assignment_id=assignment_id,
-            )
-            if assignment is not None and assignment.status != "completed":
-                raise ValueError("Post-play feedback can only be submitted for completed assignments.")
-            if assignment is not None:
-                after_form_keys = set(assignment.data.get(MongoColumns.FORM_RESPONSES, {}).keys())
-                required_after_form_names = {form.name for form in after_forms}
-                if required_after_form_names.issubset(after_form_keys):
-                    raise ValueError("Post-play feedback has already been submitted for this assignment.")
-        else:
-            state = await cls.get_player_state_async(provider=provider, experiment_name=config.name, player_id=player_id)
-            assignment = state["pending_post_play"]
-        if assignment is None:
-            raise ValueError("No completed assignment is waiting for a post-play response.")
-
-        normalized_after_forms = cls.normalize_form_submissions(forms=after_forms, responses=responses)
-        stored = await cls.store_form_payloads_async(
-            provider=provider,
-            assignment_id=assignment.assignment_id,
-            forms_payload=normalized_after_forms,
-        )
-        if stored is None:
-            raise ValueError("Failed to store the post-play response.")
-        return stored
 
     @classmethod
     async def store_form_payloads_async(
@@ -662,7 +726,7 @@ class ExperimentManager:
 
             normalized[form.name] = {
                 "form_name": form.name,
-                "before_or_after": form.before_or_after,
+                "trigger": form.trigger.model_dump(mode="json"),
                 "submitted_at": utc_now(),
                 "answers": normalized_answers,
             }

--- a/dcs_simulation_engine/core/forms.py
+++ b/dcs_simulation_engine/core/forms.py
@@ -11,6 +11,20 @@ from pydantic import (
     model_validator,
 )
 
+FormTriggerEvent = Literal[
+    "before_all_assignments",
+    "before_assignment",
+    "after_assignment",
+    "after_all_assignments",
+]
+
+REGISTERED_FORM_TRIGGER_EVENTS = {
+    "before_all_assignments",
+    "before_assignment",
+    "after_assignment",
+    "after_all_assignments",
+}
+
 
 def _normalize_identifier(value: str) -> str:
     """Normalize an identifier into lowercase snake_case."""
@@ -52,13 +66,31 @@ class ExperimentFormQuestion(BaseModel):
         return self
 
 
+class ExperimentFormTrigger(BaseModel):
+    """Canonical trigger for experiment forms."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    event: FormTriggerEvent
+    match: Any = None
+
+    @model_validator(mode="after")
+    def validate_registered_trigger(self) -> "ExperimentFormTrigger":
+        """Validate event registration and v1 match support."""
+        if self.event not in REGISTERED_FORM_TRIGGER_EVENTS:
+            raise ValueError(f"Unknown form trigger event: {self.event}")
+        if self.match is not None:
+            raise ValueError("Form trigger match must be null for the current built-in triggers.")
+        return self
+
+
 class ExperimentForm(BaseModel):
-    """Named experiment form shown before or after gameplay."""
+    """Named experiment form shown at a registered experiment trigger."""
 
     model_config = ConfigDict(extra="forbid")
 
     name: str
-    before_or_after: Literal["before", "after"]
+    trigger: ExperimentFormTrigger
     questions: list[ExperimentFormQuestion] = Field(default_factory=list)
 
     @field_validator("name")

--- a/examples/run_configs/benchmark-humans.yml
+++ b/examples/run_configs/benchmark-humans.yml
@@ -41,7 +41,9 @@ next_game_strategy:
 # DATA COLLECTION FORMS
 forms:
   - name: research_participation_consent
-    trigger: before_all
+    trigger:
+      event: before_all_assignments
+      match: null
     questions:
       - type: message
         prompt: |
@@ -69,10 +71,14 @@ forms:
         required: false
 
   - name: intake
-    trigger: before_all
+    trigger:
+      event: before_all_assignments
+      match: null
     questions:
       - ...
   - name: outtake
-    trigger: after_all
+    trigger:
+      event: after_all_assignments
+      match: null
     questions:
       - ...

--- a/examples/run_configs/expert-evaluation.yml
+++ b/examples/run_configs/expert-evaluation.yml
@@ -36,7 +36,9 @@ next_game_strategy:
 
 forms:
   - name: research_participation_consent
-    trigger: before_all
+    trigger:
+      event: before_all_assignments
+      match: null
     questions:
       - type: message
         prompt: |
@@ -63,14 +65,20 @@ forms:
           - I consent to participate in this research study.
         required: false
   - name: expertise_intake
-    trigger: before_all
+    trigger:
+      event: before_all_assignments
+      match: null
     questions:
       - ...
   - name: post_game_feedback
-    trigger: after_each
+    trigger:
+      event: after_assignment
+      match: null
     questions:
       - ...
   - name: outtake
-    trigger: after_all
+    trigger:
+      event: after_all_assignments
+      match: null
     questions:
       - ...

--- a/examples/run_configs/training.yml
+++ b/examples/run_configs/training.yml
@@ -31,7 +31,9 @@ next_game_strategy:
 # DATA COLLECTION FORMS
 forms:
   - name: training_consent
-    trigger: before_all
+    trigger:
+      event: before_all_assignments
+      match: null
     questions:
       - type: message
         prompt: |

--- a/examples/run_configs/usability.yml
+++ b/examples/run_configs/usability.yml
@@ -33,7 +33,9 @@ next_game_strategy:
 # DATA COLLECTION FORMS
 forms:
   - name: research_participation_consent
-    trigger: before_all
+    trigger:
+      event: before_all_assignments
+      match: null
     questions:
       - type: message
         prompt: |
@@ -61,10 +63,14 @@ forms:
         required: false
 
   - name: intake
-    trigger: before_all
+    trigger:
+      event: before_all_assignments
+      match: null
     questions:
       - ...
   - name: outtake
-    trigger: after_all
+    trigger:
+      event: after_all_assignments
+      match: null
     questions:
       - ...

--- a/experiments/usability.yml
+++ b/experiments/usability.yml
@@ -13,7 +13,9 @@ assignment_strategy:
   require_completion: false
 forms:
   - name: intake
-    before_or_after: before # "before" | "after"
+    trigger:
+      event: before_all_assignments
+      match: null
     questions:
       - key: professional_background
         prompt: Describe your professional background (e.g., industry, role, years of
@@ -35,7 +37,9 @@ forms:
         answer_type: string
         required: true
   - name: outtake
-    before_or_after: after
+    trigger:
+      event: after_assignment
+      match: null
     questions:
       - key: usability_difficulty
         prompt: What parts were confusing or difficult? (e.g., understanding what to do,

--- a/tests/functional/test_server.py
+++ b/tests/functional/test_server.py
@@ -925,7 +925,7 @@ def test_experiment_setup_returns_metadata_and_assignment_state(
     """Experiment setup should return forms, progress, and the current assignment state."""
     form = ExperimentForm(
         name="intake",
-        before_or_after="before",
+        trigger={"event": "before_all_assignments", "match": None},
         questions=[
             ExperimentFormQuestion(
                 key="full_name",
@@ -979,6 +979,7 @@ def test_experiment_setup_returns_metadata_and_assignment_state(
                     "has_finished_experiment": False,
                     "has_submitted_before_forms": True,
                     "eligible_assignment_options": [],
+                    "pending_form_groups": [],
                     "assignments": [assignment],
                 }
             ),
@@ -1003,51 +1004,35 @@ def test_experiment_setup_returns_metadata_and_assignment_state(
     assert payload["require_completion"] is True
     assert payload["has_submitted_before_forms"] is True
     assert payload["eligible_assignment_options"] == []
+    assert payload["pending_form_groups"] == []
     assert "character_hid" not in payload["current_assignment"]
     assert payload["current_assignment"]["game_description"] == "Game description"
     assert payload["forms"][0]["name"] == "intake"
 
 
 @pytest.mark.unit
-def test_experiment_before_play_submission_returns_assignment(
+def test_experiment_form_group_submission_returns_group(
     client: TestClient,
 ) -> None:
-    """Experiment before-play submission should return the current assignment for the signed-in player."""
-    assignment = SimpleNamespace(
-        assignment_id="asg-2",
-        game_name="Foresight",
-        pc_hid="pc-2",
-        npc_hid="npc-2",
-        status="assigned",
-    )
+    """Experiment form submission should store one pending group."""
+    group = {
+        "group_id": "before_all_assignments",
+        "trigger": {"event": "before_all_assignments", "match": None},
+    }
 
-    with (
-        patch(
-            "dcs_simulation_engine.api.routers.experiments.ExperimentManager.submit_before_play_async",
-            new=AsyncMock(return_value=assignment),
-        ),
-        patch(
-            "dcs_simulation_engine.api.routers.experiments.ExperimentManager.assignment_display_metadata_async",
-            new=AsyncMock(return_value=ASSIGNMENT_DISPLAY_METADATA),
-        ),
-    ):
+    with patch(
+        "dcs_simulation_engine.api.routers.experiments.ExperimentManager.submit_form_group_async",
+        new=AsyncMock(return_value=group),
+    ) as submit_mock:
         response = client.post(
-            "/api/experiments/usability/players",
+            "/api/experiments/usability/forms/submit",
             headers={"Authorization": "Bearer valid-key"},
-            json={"responses": {"intake": {"full_name": "Ada"}}},
+            json={"group_id": "before_all_assignments", "responses": {"intake": {"full_name": "Ada"}}},
         )
 
     assert response.status_code == 200
-    assert response.json()["assignment"] == {
-        "assignment_id": "asg-2",
-        "game_name": "Foresight",
-        "pc_hid": "pc-2",
-        "npc_hid": "npc-2",
-        "status": "assigned",
-        "active_session_id": None,
-        "needs_post_play": False,
-        **ASSIGNMENT_DISPLAY_METADATA,
-    }
+    assert response.json() == group | {"assignment_id": None}
+    assert submit_mock.await_args.kwargs["group_id"] == "before_all_assignments"
 
 
 @pytest.mark.unit
@@ -1186,6 +1171,7 @@ def test_experiment_multiple_assignments_can_each_be_resumed(
 
     headers = {"Authorization": f"Bearer {access_key}"}
     entry_payload = {
+        "group_id": "before_all_assignments",
         "responses": {
             "intake": {
                 "professional_background": "Research engineer",
@@ -1197,7 +1183,7 @@ def test_experiment_multiple_assignments_can_each_be_resumed(
 
     with TestClient(app) as client:
         before_play = client.post(
-            "/api/experiments/usability/players",
+            "/api/experiments/usability/forms/submit",
             headers=headers,
             json=entry_payload,
         )
@@ -1275,43 +1261,29 @@ def test_experiment_multiple_assignments_can_each_be_resumed(
 
 
 @pytest.mark.unit
-def test_experiment_post_play_submission_persists_response(client: TestClient) -> None:
-    """Experiment post-play submission should target the latest completed assignment."""
-    assignment = SimpleNamespace(
-        assignment_id="asg-complete-1",
-        game_name="Explore",
-        pc_hid="pc-1",
-        npc_hid="npc-1",
-        status="completed",
-    )
+def test_experiment_assignment_form_group_submission_persists_response(client: TestClient) -> None:
+    """Experiment form submission should accept assignment-scoped groups."""
+    group = {
+        "group_id": "after_assignment:asg-complete-1",
+        "trigger": {"event": "after_assignment", "match": None},
+        "assignment_id": "asg-complete-1",
+    }
 
-    with (
-        patch(
-            "dcs_simulation_engine.api.routers.experiments.ExperimentManager.store_post_play_async",
-            new=AsyncMock(return_value=assignment),
-        ),
-        patch(
-            "dcs_simulation_engine.api.routers.experiments.ExperimentManager.assignment_display_metadata_async",
-            new=AsyncMock(return_value=ASSIGNMENT_DISPLAY_METADATA),
-        ),
+    with patch(
+        "dcs_simulation_engine.api.routers.experiments.ExperimentManager.submit_form_group_async",
+        new=AsyncMock(return_value=group),
     ):
         response = client.post(
-            "/api/experiments/usability/post-play",
+            "/api/experiments/usability/forms/submit",
             headers={"Authorization": "Bearer valid-key"},
-            json={"responses": {"usability_feedback": {"usability_issues": "None"}}},
+            json={
+                "group_id": "after_assignment:asg-complete-1",
+                "responses": {"usability_feedback": {"usability_issues": "None"}},
+            },
         )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "assignment_id": "asg-complete-1",
-        "game_name": "Explore",
-        "pc_hid": "pc-1",
-        "npc_hid": "npc-1",
-        "status": "completed",
-        "active_session_id": None,
-        "needs_post_play": False,
-        **ASSIGNMENT_DISPLAY_METADATA,
-    }
+    assert response.json() == group
 
 
 @pytest.mark.unit

--- a/tests/unit/core/conftest.py
+++ b/tests/unit/core/conftest.py
@@ -44,7 +44,9 @@ def usability_experiment_config_path(write_yaml: Callable[[str, str], Path]) -> 
           seed: test-usability-seed
         forms:
           - name: intake
-            before_or_after: before
+            trigger:
+              event: before_all_assignments
+              match: null
             questions:
               - prompt: Please complete the intake form.
               - key: age
@@ -76,7 +78,9 @@ def usability_experiment_config_path(write_yaml: Callable[[str, str], Path]) -> 
                 prompt: Briefly describe your technical experience
                 answer_type: string
           - name: usability_feedback
-            before_or_after: after
+            trigger:
+              event: after_assignment
+              match: null
             questions:
               - prompt: Please share any usability feedback.
               - key: usability_issues
@@ -136,14 +140,18 @@ def multi_assignment_experiment_config_path(write_yaml: Callable[[str, str], Pat
           seed: test-multi-seed
         forms:
           - name: intake
-            before_or_after: before
+            trigger:
+              event: before_all_assignments
+              match: null
             questions:
               - key: age
                 prompt: Age
                 answer_type: number
                 required: true
           - name: usability_feedback
-            before_or_after: after
+            trigger:
+              event: after_assignment
+              match: null
             questions:
               - key: usability_issues
                 prompt: Any issues?

--- a/tests/unit/core/test_experiment_config.py
+++ b/tests/unit/core/test_experiment_config.py
@@ -18,6 +18,8 @@ async def test_load_valid_usability_experiment_config(usability_experiment_confi
     assert config.assignment_strategy.require_completion is True
     assert len(config.games) == 4
     assert [form.name for form in config.forms] == ["intake", "usability_feedback"]
+    assert config.forms[0].trigger.event == "before_all_assignments"
+    assert config.forms[1].trigger.event == "after_assignment"
 
 
 async def test_legacy_assignment_protocol_key_is_rejected(write_yaml) -> None:
@@ -138,7 +140,9 @@ async def test_invalid_form_field_type_fails(write_yaml) -> None:
           max_assignments_per_player: 1
         forms:
           - name: intake
-            before_or_after: before
+            trigger:
+              event: before_all_assignments
+              match: null
             questions:
               - key: technical_savviness
                 prompt: Savvy
@@ -151,6 +155,83 @@ async def test_invalid_form_field_type_fails(write_yaml) -> None:
         ExperimentConfig.load(path)
 
 
+async def test_legacy_before_or_after_form_key_is_rejected(write_yaml) -> None:
+    """Forms must use canonical trigger objects."""
+    path = write_yaml(
+        "legacy-form-trigger.yaml",
+        """
+        name: legacy-form-trigger
+        description: Broken
+        assignment_strategy:
+          strategy: random_unique_game
+          games:
+            - Explore
+          quota_per_game: 1
+          max_assignments_per_player: 1
+        forms:
+          - name: intake
+            before_or_after: before
+            questions: []
+        """,
+    )
+
+    with pytest.raises(ValueError, match="trigger"):
+        ExperimentConfig.load(path)
+
+
+async def test_unknown_form_trigger_event_is_rejected(write_yaml) -> None:
+    """Only registered form trigger events are accepted."""
+    path = write_yaml(
+        "unknown-form-trigger.yaml",
+        """
+        name: unknown-form-trigger
+        description: Broken
+        assignment_strategy:
+          strategy: random_unique_game
+          games:
+            - Explore
+          quota_per_game: 1
+          max_assignments_per_player: 1
+        forms:
+          - name: intake
+            trigger:
+              event: before_everything
+              match: null
+            questions: []
+        """,
+    )
+
+    with pytest.raises(ValueError, match="before_all_assignments"):
+        ExperimentConfig.load(path)
+
+
+async def test_form_trigger_match_must_be_null(write_yaml) -> None:
+    """Current built-in triggers do not accept match filters."""
+    path = write_yaml(
+        "matched-form-trigger.yaml",
+        """
+        name: matched-form-trigger
+        description: Broken
+        assignment_strategy:
+          strategy: random_unique_game
+          games:
+            - Explore
+          quota_per_game: 1
+          max_assignments_per_player: 1
+        forms:
+          - name: intake
+            trigger:
+              event: before_all_assignments
+              match:
+                game: Explore
+            questions: []
+        """,
+    )
+
+    with pytest.raises(ValueError, match="match must be null"):
+        ExperimentConfig.load(path)
+
+
 async def test_experiment_config_snapshot_is_serializable(usability_experiment_config) -> None:
     """Experiment config snapshots should be JSON-friendly for DB storage."""
     config = usability_experiment_config
@@ -159,4 +240,5 @@ async def test_experiment_config_snapshot_is_serializable(usability_experiment_c
     assert snapshot["name"] == "test-usability-exp"
     assert snapshot["assignment_strategy"]["max_assignments_per_player"] == 1
     assert snapshot["forms"][0]["name"] == "intake"
+    assert snapshot["forms"][0]["trigger"] == {"event": "before_all_assignments", "match": None}
     assert "age" in [question["key"] for question in snapshot["forms"][0]["questions"]]

--- a/tests/unit/core/test_experiment_manager.py
+++ b/tests/unit/core/test_experiment_manager.py
@@ -29,14 +29,24 @@ def _cache_config(config: ExperimentConfig):
     return original_cache
 
 
-async def test_submit_before_play_stores_entry_form_in_forms_collection(async_mongo_provider, cached_usability_experiment) -> None:
+async def _submit_entry_forms(async_mongo_provider, config: ExperimentConfig, player_id: str) -> None:
+    await ExperimentManager.submit_form_group_async(
+        provider=async_mongo_provider,
+        experiment_name=config.name,
+        player_id=player_id,
+        group_id="before_all_assignments",
+        responses=_entry_form_payload(),
+    )
+
+
+async def test_submit_form_group_stores_entry_form_in_forms_collection(async_mongo_provider, cached_usability_experiment) -> None:
     """Submitting before-play answers should persist the form in the forms collection, not on the assignment."""
     player, _ = await async_mongo_provider.create_player(player_data={"full_name": {"answer": "Ada Lovelace"}})
-    assignment = await ExperimentManager.submit_before_play_async(
+    await _submit_entry_forms(async_mongo_provider, cached_usability_experiment, player.id)
+    assignment = await ExperimentManager.get_or_create_assignment_async(
         provider=async_mongo_provider,
         experiment_name=cached_usability_experiment.name,
-        player_id=player.id,
-        responses=_entry_form_payload(),
+        player=player,
     )
 
     assert assignment is not None
@@ -81,6 +91,7 @@ def test_is_completion_reason(reason: str, expected: bool) -> None:
 async def test_interrupted_assignment_is_reused(async_mongo_provider, cached_usability_experiment) -> None:
     """Interrupted assignments should be returned again instead of generating a new row."""
     player, _ = await async_mongo_provider.create_player(player_data={"full_name": {"answer": "Ada"}})
+    await _submit_entry_forms(async_mongo_provider, cached_usability_experiment, player.id)
     first = await ExperimentManager.get_or_create_assignment_async(
         provider=async_mongo_provider,
         experiment_name=cached_usability_experiment.name,
@@ -105,6 +116,7 @@ async def test_interrupted_assignment_is_reused(async_mongo_provider, cached_usa
 async def test_completed_assignment_blocks_further_assignment_when_max_is_one(async_mongo_provider, cached_usability_experiment) -> None:
     """A player should stop receiving assignments after one completed game when max_assignments=1."""
     player, _ = await async_mongo_provider.create_player(player_data={"full_name": {"answer": "Bob"}})
+    await _submit_entry_forms(async_mongo_provider, cached_usability_experiment, player.id)
     assignment = await ExperimentManager.get_or_create_assignment_async(
         provider=async_mongo_provider,
         experiment_name=cached_usability_experiment.name,
@@ -130,11 +142,11 @@ async def test_post_play_completion_marks_experiment_finished_after_single_assig
 ) -> None:
     """Once post-play feedback is complete, single-game participants should be marked finished."""
     player, _ = await async_mongo_provider.create_player(player_data={"full_name": {"answer": "Dana"}})
-    first = await ExperimentManager.submit_before_play_async(
+    await _submit_entry_forms(async_mongo_provider, cached_usability_experiment, player.id)
+    first = await ExperimentManager.get_or_create_assignment_async(
         provider=async_mongo_provider,
         experiment_name=cached_usability_experiment.name,
-        player_id=player.id,
-        responses=_entry_form_payload(),
+        player=player,
     )
     assert first is not None
 
@@ -142,10 +154,11 @@ async def test_post_play_completion_marks_experiment_finished_after_single_assig
         assignment_id=first.assignment_id,
         status="completed",
     )
-    await ExperimentManager.store_post_play_async(
+    await ExperimentManager.submit_form_group_async(
         provider=async_mongo_provider,
         experiment_name=cached_usability_experiment.name,
         player_id=player.id,
+        group_id=f"after_assignment:{first.assignment_id}",
         responses={
             "usability_feedback": {
                 "usability_issues": "None",
@@ -165,6 +178,121 @@ async def test_post_play_completion_marks_experiment_finished_after_single_assig
     assert state["pending_post_play"] is None
     assert state["active_assignment"] is None
     assert state["has_finished_experiment"] is True
+
+
+async def test_before_assignment_forms_are_pending_per_assignment(async_mongo_provider, write_yaml) -> None:
+    """Before-assignment triggers should attach to the assignment they gate."""
+    path = write_yaml(
+        "before-assignment-forms.yaml",
+        """
+        name: before-assignment-forms
+        description: Trigger fixture
+        assignment_strategy:
+          strategy: random_unique_game
+          games:
+            - Explore
+          quota_per_game: 1
+          max_assignments_per_player: 1
+        forms:
+          - name: pre_game
+            trigger:
+              event: before_assignment
+              match: null
+            questions:
+              - key: ready
+                prompt: Ready?
+                answer_type: bool
+                required: true
+        """,
+    )
+    config = ExperimentConfig.load(Path(path))
+    original_cache = _cache_config(config)
+    player, _ = await async_mongo_provider.create_player(player_data={"full_name": {"answer": "Pre"}})
+
+    try:
+        assignment = await ExperimentManager.get_or_create_assignment_async(
+            provider=async_mongo_provider,
+            experiment_name=config.name,
+            player=player,
+        )
+        assert assignment is not None
+        state = await ExperimentManager.get_player_state_async(
+            provider=async_mongo_provider,
+            experiment_name=config.name,
+            player_id=player.id,
+        )
+        assert state["pending_form_groups"][0]["group_id"] == f"before_assignment:{assignment.assignment_id}"
+
+        await ExperimentManager.submit_form_group_async(
+            provider=async_mongo_provider,
+            experiment_name=config.name,
+            player_id=player.id,
+            group_id=f"before_assignment:{assignment.assignment_id}",
+            responses={"pre_game": {"ready": True}},
+        )
+        state_after = await ExperimentManager.get_player_state_async(
+            provider=async_mongo_provider,
+            experiment_name=config.name,
+            player_id=player.id,
+        )
+    finally:
+        ExperimentManager._experiment_config_cache = original_cache
+
+    assert state_after["pending_form_groups"] == []
+
+
+async def test_after_all_assignment_forms_are_pending_after_completion(async_mongo_provider, write_yaml) -> None:
+    """After-all triggers should wait until all required assignments are completed."""
+    path = write_yaml(
+        "after-all-forms.yaml",
+        """
+        name: after-all-forms
+        description: Trigger fixture
+        assignment_strategy:
+          strategy: random_unique_game
+          games:
+            - Explore
+          quota_per_game: 1
+          max_assignments_per_player: 1
+        forms:
+          - name: exit
+            trigger:
+              event: after_all_assignments
+              match: null
+            questions:
+              - key: done
+                prompt: Done?
+                answer_type: bool
+                required: true
+        """,
+    )
+    config = ExperimentConfig.load(Path(path))
+    original_cache = _cache_config(config)
+    player, _ = await async_mongo_provider.create_player(player_data={"full_name": {"answer": "Post"}})
+
+    try:
+        assignment = await ExperimentManager.get_or_create_assignment_async(
+            provider=async_mongo_provider,
+            experiment_name=config.name,
+            player=player,
+        )
+        assert assignment is not None
+        before_done = await ExperimentManager.get_player_state_async(
+            provider=async_mongo_provider,
+            experiment_name=config.name,
+            player_id=player.id,
+        )
+        await async_mongo_provider.update_assignment_status(assignment_id=assignment.assignment_id, status="completed")
+        after_done = await ExperimentManager.get_player_state_async(
+            provider=async_mongo_provider,
+            experiment_name=config.name,
+            player_id=player.id,
+        )
+    finally:
+        ExperimentManager._experiment_config_cache = original_cache
+
+    assert before_done["pending_form_groups"] == []
+    assert after_done["pending_form_groups"][0]["group_id"] == "after_all_assignments"
 
 
 async def test_progress_counts_completed_assignments_and_unique_players(async_mongo_provider, cached_usability_experiment) -> None:
@@ -436,6 +564,7 @@ async def test_get_or_create_assignment_uses_first_strategy_candidate(
 ) -> None:
     """ExperimentManager should create the first ordered strategy candidate when choice is disabled."""
     player, _ = await async_mongo_provider.create_player(player_data={"full_name": {"answer": "Delegated"}})
+    await _submit_entry_forms(async_mongo_provider, cached_usability_experiment, player.id)
     strategy = MagicMock()
     strategy.max_assignments_per_player.return_value = 1
     strategy.list_candidate_assignments_async = AsyncMock(
@@ -701,10 +830,11 @@ async def test_completed_assignment_reflected_in_player_state_after_multi_assign
     player, _ = await async_mongo_provider.create_player(player_data={"full_name": {"answer": "Progress Tester"}})
 
     # Register: creates the first assignment.
-    await ExperimentManager.submit_before_play_async(
+    await ExperimentManager.submit_form_group_async(
         provider=async_mongo_provider,
         experiment_name=cached_multi_assignment_experiment.name,
         player_id=player.id,
+        group_id="before_all_assignments",
         responses={"intake": {"age": 30}},
     )
 
@@ -724,10 +854,11 @@ async def test_completed_assignment_reflected_in_player_state_after_multi_assign
     )
 
     # Submit post-play so pending_post_play is cleared.
-    await ExperimentManager.store_post_play_async(
+    await ExperimentManager.submit_form_group_async(
         provider=async_mongo_provider,
         experiment_name=cached_multi_assignment_experiment.name,
         player_id=player.id,
+        group_id=f"after_assignment:{active.assignment_id}",
         responses={
             "usability_feedback": {
                 "usability_issues": "",

--- a/ui/src/routes/experiments/$experimentName.tsx
+++ b/ui/src/routes/experiments/$experimentName.tsx
@@ -711,9 +711,10 @@ function ExperimentPage() {
   ).length
 
   useEffect(() => {
+    const nextForms = data?.pending_form_groups?.[0]?.forms ?? []
     setFormErrors({})
-    setFormResponses(pendingForms.length ? emptyResponses(pendingForms) : {})
-  }, [pendingFormGroup?.group_id])
+    setFormResponses(nextForms.length ? emptyResponses(nextForms) : {})
+  }, [data?.pending_form_groups])
 
   function setResponse(
     setter: React.Dispatch<React.SetStateAction<FormResponseMap>>,
@@ -950,9 +951,7 @@ function ExperimentPage() {
 
             {needsBeforeForms && (
               <Alert>
-                <AlertDescription>
-                  Complete the required form to unlock gameplay.
-                </AlertDescription>
+                <AlertDescription>Complete the required form to unlock gameplay.</AlertDescription>
               </Alert>
             )}
 

--- a/ui/src/routes/experiments/$experimentName.tsx
+++ b/ui/src/routes/experiments/$experimentName.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { createRoute, redirect, useNavigate, useParams } from '@tanstack/react-router'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { HttpError, httpClient } from '@/api/http'
 import { FatalErrorOverlay } from '@/components/fatal-error-overlay'
 import { ThemeToggle } from '@/components/theme-toggle'
@@ -46,7 +46,14 @@ interface ExperimentQuestion {
 
 interface ExperimentFormSchema {
   name: string
-  before_or_after: 'before' | 'after'
+  trigger: {
+    event:
+      | 'before_all_assignments'
+      | 'before_assignment'
+      | 'after_assignment'
+      | 'after_all_assignments'
+    match: null
+  }
   questions: ExperimentQuestion[]
 }
 
@@ -94,6 +101,7 @@ interface ExperimentSetupResponse {
   description: string
   is_open: boolean
   forms: ExperimentFormSchema[]
+  pending_form_groups: PendingFormGroup[]
   progress: ExperimentProgressResponse
   current_assignment: ExperimentAssignmentSummary | null
   pending_post_play: boolean
@@ -108,8 +116,17 @@ interface ExperimentSetupResponse {
   resumable_session_id?: string | null
 }
 
-interface ExperimentPlayerResponse {
-  assignment: ExperimentAssignmentSummary | null
+interface PendingFormGroup {
+  group_id: string
+  trigger: ExperimentFormSchema['trigger']
+  forms: ExperimentFormSchema[]
+  assignment_id?: string | null
+}
+
+interface ExperimentFormSubmitResponse {
+  group_id: string
+  trigger: ExperimentFormSchema['trigger']
+  assignment_id?: string | null
 }
 
 function titleCase(value: string): string {
@@ -117,6 +134,13 @@ function titleCase(value: string): string {
     .split('_')
     .join(' ')
     .replace(/\b\w/g, (match) => match.toUpperCase())
+}
+
+function triggerLabel(trigger: ExperimentFormSchema['trigger']): string {
+  if (trigger.event === 'before_all_assignments') return 'Before Study'
+  if (trigger.event === 'before_assignment') return 'Before Gameplay'
+  if (trigger.event === 'after_assignment') return 'After Gameplay'
+  return 'After Study'
 }
 
 function emptyResponses(forms: ExperimentFormSchema[]): FormResponseMap {
@@ -396,9 +420,7 @@ function FormSection(props: {
           <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">Form</p>
           <h3 className="text-lg font-semibold">{titleCase(form.name)}</h3>
         </div>
-        <Badge variant="outline">
-          {form.before_or_after === 'before' ? 'Before Play' : 'After Play'}
-        </Badge>
+        <Badge variant="outline">{triggerLabel(form.trigger)}</Badge>
       </div>
       {form.questions.map((question) => (
         <QuestionField
@@ -647,12 +669,10 @@ function ExperimentPage() {
   const { experimentName } = useParams({ from: '/experiments/$experimentName' })
   const navigate = useNavigate()
   const authenticated = isAuthenticated()
-  const [entryResponses, setEntryResponses] = useState<FormResponseMap>({})
-  const [entryErrors, setEntryErrors] = useState<Record<string, Record<string, string>>>({})
-  const [postResponses, setPostResponses] = useState<FormResponseMap>({})
-  const [postErrors, setPostErrors] = useState<Record<string, Record<string, string>>>({})
+  const [formResponses, setFormResponses] = useState<FormResponseMap>({})
+  const [formErrors, setFormErrors] = useState<Record<string, Record<string, string>>>({})
   const [submitError, setSubmitError] = useState<string | null>(null)
-  const [submitting, setSubmitting] = useState<'entry' | 'session' | 'post' | 'select' | null>(null)
+  const [submitting, setSubmitting] = useState<'form' | 'session' | 'select' | null>(null)
   const [selectedGame, setSelectedGame] = useState<string | null>(null)
   const [selectedPc, setSelectedPc] = useState<string | null>(null)
   const [selectedNpc, setSelectedNpc] = useState<string | null>(null)
@@ -672,43 +692,28 @@ function ExperimentPage() {
   })
 
   const nextAssignment = data?.next_assignment ?? null
+  const pendingFormGroup = data?.pending_form_groups?.[0] ?? null
+  const pendingForms = pendingFormGroup?.forms ?? []
   const eligibleOptions =
     nextAssignment?.mode === 'choice'
       ? nextAssignment.options
       : (data?.eligible_assignment_options ?? [])
   const needsSelection = nextAssignment?.mode === 'choice'
   const needsBeforeForms =
-    nextAssignment?.mode === 'blocked' && nextAssignment.reason === 'before_forms'
+    nextAssignment?.mode === 'blocked' && nextAssignment.reason === 'pending_forms'
   const noAssignmentsAvailable =
     nextAssignment?.mode === 'none' &&
     (nextAssignment.reason === 'unavailable' || nextAssignment.reason === 'quota_closed')
 
-  const beforeForms = useMemo(
-    () => (data?.forms ?? []).filter((form) => form.before_or_after === 'before'),
-    [data?.forms],
-  )
-  const afterForms = useMemo(
-    () => (data?.forms ?? []).filter((form) => form.before_or_after === 'after'),
-    [data?.forms],
-  )
   const lockedAssignment = nextAssignment?.mode === 'locked' ? nextAssignment.assignment : null
   const unfinishedAssignmentCount = (data?.assignments ?? []).filter(
     (assignment) => assignment.status !== 'completed',
   ).length
 
   useEffect(() => {
-    if (!beforeForms.length) return
-    setEntryResponses((current) =>
-      Object.keys(current).length > 0 ? current : emptyResponses(beforeForms),
-    )
-  }, [beforeForms])
-
-  useEffect(() => {
-    if (!afterForms.length) return
-    setPostResponses((current) =>
-      Object.keys(current).length > 0 ? current : emptyResponses(afterForms),
-    )
-  }, [afterForms])
+    setFormErrors({})
+    setFormResponses(pendingForms.length ? emptyResponses(pendingForms) : {})
+  }, [pendingFormGroup?.group_id])
 
   function setResponse(
     setter: React.Dispatch<React.SetStateAction<FormResponseMap>>,
@@ -730,25 +735,26 @@ function ExperimentPage() {
     await navigate({ to: '/login' })
   }
 
-  async function handleEntrySubmit(event: React.FormEvent) {
+  async function handleFormSubmit(event: React.FormEvent) {
     event.preventDefault()
-    const errors = validateResponses(beforeForms, entryResponses)
-    setEntryErrors(errors)
+    if (!pendingFormGroup) return
+    const errors = validateResponses(pendingForms, formResponses)
+    setFormErrors(errors)
     if (Object.keys(errors).length > 0) return
 
     setSubmitError(null)
-    setSubmitting('entry')
+    setSubmitting('form')
     try {
-      await httpClient<ExperimentPlayerResponse>(
-        `/api/experiments/${encodeURIComponent(experimentName)}/players`,
+      await httpClient<ExperimentFormSubmitResponse>(
+        `/api/experiments/${encodeURIComponent(experimentName)}/forms/submit`,
         {
           method: 'POST',
-          body: JSON.stringify({ responses: entryResponses }),
+          body: JSON.stringify({ group_id: pendingFormGroup.group_id, responses: formResponses }),
         },
       )
       await refetch()
     } catch (submitErr) {
-      setSubmitError(submitErr instanceof Error ? submitErr.message : 'Registration failed')
+      setSubmitError(submitErr instanceof Error ? submitErr.message : 'Unable to submit form.')
     } finally {
       setSubmitting(null)
     }
@@ -783,29 +789,6 @@ function ExperimentPage() {
       setSubmitError(
         submitErr instanceof Error ? submitErr.message : 'Unable to start the session.',
       )
-    } finally {
-      setSubmitting(null)
-    }
-  }
-
-  async function handlePostPlaySubmit(event: React.FormEvent) {
-    event.preventDefault()
-    const errors = validateResponses(afterForms, postResponses)
-    setPostErrors(errors)
-    if (Object.keys(errors).length > 0) return
-
-    setSubmitError(null)
-    setSubmitting('post')
-    try {
-      await httpClient(`/api/experiments/${encodeURIComponent(experimentName)}/post-play`, {
-        method: 'POST',
-        body: JSON.stringify({ responses: postResponses }),
-      })
-      setPostErrors({})
-      setPostResponses(emptyResponses(afterForms))
-      await refetch()
-    } catch (submitErr) {
-      setSubmitError(submitErr instanceof Error ? submitErr.message : 'Unable to submit feedback.')
     } finally {
       setSubmitting(null)
     }
@@ -895,14 +878,7 @@ function ExperimentPage() {
     )
   }
 
-  const showBeforeFormOverlay =
-    needsBeforeForms &&
-    data.is_open &&
-    !data.pending_post_play &&
-    !lockedAssignment &&
-    !data.assignment_completed
-  const showPostPlayOverlay = data.pending_post_play
-  const showFormOverlay = showBeforeFormOverlay || showPostPlayOverlay
+  const showFormOverlay = Boolean(pendingFormGroup)
   const pageDimmed = showFormOverlay
   const assignments = data.assignments ?? []
 
@@ -975,7 +951,7 @@ function ExperimentPage() {
             {needsBeforeForms && (
               <Alert>
                 <AlertDescription>
-                  Complete the required form to unlock gameplay selection.
+                  Complete the required form to unlock gameplay.
                 </AlertDescription>
               </Alert>
             )}
@@ -1057,34 +1033,19 @@ function ExperimentPage() {
           </CardContent>
         </Card>
       </div>
-      {showBeforeFormOverlay && (
+      {pendingFormGroup && (
         <FormOverlay
-          title="Complete Intake"
-          description="Answer the required questions before choosing your next gameplay session."
-          forms={beforeForms}
-          responses={entryResponses}
-          errors={entryErrors}
+          title={triggerLabel(pendingFormGroup.trigger)}
+          description="Complete the required form before continuing."
+          forms={pendingForms}
+          responses={formResponses}
+          errors={formErrors}
           submitError={submitError}
-          submitting={submitting === 'entry'}
-          submitLabel="Continue to Gameplay"
-          submittingLabel="Preparing gameplay session…"
-          onSubmit={handleEntrySubmit}
-          onChange={(formName, key, value) => setResponse(setEntryResponses, formName, key, value)}
-        />
-      )}
-      {showPostPlayOverlay && (
-        <FormOverlay
-          title="Submit Feedback"
-          description="Complete the required feedback form before continuing to another gameplay session."
-          forms={afterForms}
-          responses={postResponses}
-          errors={postErrors}
-          submitError={submitError}
-          submitting={submitting === 'post'}
-          submitLabel="Submit Feedback"
+          submitting={submitting === 'form'}
+          submitLabel="Submit"
           submittingLabel="Submitting…"
-          onSubmit={handlePostPlaySubmit}
-          onChange={(formName, key, value) => setResponse(setPostResponses, formName, key, value)}
+          onSubmit={handleFormSubmit}
+          onChange={(formName, key, value) => setResponse(setFormResponses, formName, key, value)}
         />
       )}
     </div>


### PR DESCRIPTION
# Form Trigger Expansion / Generalization

## Context

Forms currently support only `before` / `after` timing. This PR replaces that with a generalized, extensible trigger system using a canonical shape: `trigger: { event, match }`.

The implementation is intentionally narrow: only registered triggers are allowed, and supported trigger behavior is covered by tests. This keeps the system extensible without exploding the test surface. New triggers can be added later, but they should be introduced alongside tests.

Current built-in triggers:

- `before_all_assignments`
- `before_assignment`
- `after_assignment`
- `after_all_assignments`

## Changes

- replaces `before_or_after` with structured form triggers
- adds central trigger registry/validation
- generalizes experiment form resolution to pending trigger groups
- replaces special-case pre/post form submission flow with one generic submit path
- updates API setup state to expose actionable `pending_form_groups`
- updates configs/examples/tests to the canonical trigger format
- updates stale frontend to align with new trigger system

_Note: these triggers are also intended to be exercised by the example run configs in `examples/run_configs/*` and will include functional tests when run config refactor (#169) is complete but the specific `examples/run_configs/*` are not tested in this PR._

_Note: Due forms are treated as a backend capability lock, not a UI state. The overlay in the frontend is just presentation; the server is the source of truth and reject any action that would advance the player while required form groups are pending._