### PR TITLE
Update character development and simulation quality docs

### DIFF
--- a/docs/design/characters.md
+++ b/docs/design/characters.md
@@ -2,7 +2,7 @@
 
 *Characters* are cognitive systems that can be used as player characters (PCs) or non-player characters (NPCs) in simulations.
 
-Each character is a fixed snapshot of a cognitive system, including its persona, abilities and goals.
+Each character is a fixed snapshot of a cognitive system, including its persona, abilities, constraints, and goals.
 
 ## Core Characters
 Core characters are a curated set of cognitive systems included with the simulation engine. Each is selected to represent a distinct type of cognition—differing in goals, structure, or behavior—and is tested to ensure the engine can model it reliably.
@@ -32,13 +32,13 @@ Examples include:
 
 - And additional forms as needed
 
-👉 See our character coverage reports for character's in [development](../reports/character_coverage_report_dev.html) and [production](../reports/character_coverage_report_prod.html).
+👉 See our character coverage reports for characters in [development](../reports/character_coverage_report_dev.html) and [production](../reports/character_coverage_report_prod.html).
 
 ### Character Development
 
-Characters are defined using structured character sheets, informed by primary research and, where possible, in-person interviews.
+Characters are defined using structured character sheets, informed by primary research and, where possible, interviews or first-person experiential input.
 
-These sheets specify persona, abilities, goals, and other attributes required for simulation. They are iteratively refined to capture essential features of the cognitive system while remaining playable within the engine.
+These sheets specify narrative fields such as descriptions, abilities, persona features, and goals, along with structured dimensions such as origin, form, agency, substrate, and size. They are iteratively refined to capture essential features of the cognitive system while remaining playable within the engine.
 
 👉 See the [Custom Characters](../user_guide/advanced.md#custom-characters) section in the User Guide for the character development workflow.
 
@@ -48,13 +48,13 @@ Character behavior depends on three components:
 
 - The character sheet
 - The system prompt
-- The role-playing model (ensembles)
+- The role-playing model(s)
 
 All **evaluations are fingerprinted** against this full configuration. As a result, evaluations are valid only for the exact combination of character sheet, system prompt, and model(s) they were run against.
 
 Any change to one of these components (e.g., model version or prompt update) automatically invalidates prior evaluations and requires re-evaluation.
 
-Character quality is governed by a character **release policy** (see `character-release-policy.yml` in the repository), which defines a minimum threshold score on evaluations that is required for characters to be included in production (e.g., in-character fidelity (ICF), scenario coverage).
+Character quality is governed by a character **release policy** (see `character-release-policy.yml` in the repository), which defines the minimum evaluation thresholds required before a character is added to production, including measures such as in-character fidelity (ICF) and scenario coverage.
 
 Evaluations are conducted by internal and, when possible, external experts to ensure characters meet required thresholds.
 

--- a/docs/design/simulation_quality.md
+++ b/docs/design/simulation_quality.md
@@ -1,6 +1,6 @@
-# DCS-SE Simulation Quality Studies
+# DCS-SE Simulation Quality
 
-Simulation quality studies are re-run following modifications to characters or underlying models to demonstrate that DCS-SE continues to produce consistently high-quality role-playing behavior.
+Simulation quality checks are re-run following modifications to characters, prompts, validators, or underlying models to demonstrate that DCS-SE continues to produce consistently high-quality simulation behavior.
 
 ⚠️ TODO: link report.
 
@@ -8,9 +8,34 @@ Simulation quality studies are re-run following modifications to characters or u
 
 ---
 
-# Validator Architecture
+## Character Representational Quality
 
-## 1. Motivation
+Character representational quality is how we test and maintain whether a simulated character behaves like the cognitive system it is supposed to represent.
+
+For each character, we:
+
+- Build a structured character sheet grounded in research, interviews, or other appropriate source material
+- Generate a HITL scenario scaffold covering multiple pressure categories
+- Edit those scenarios so they actually test the representational bounds of the character
+- Run HITL updates to generate simulator outputs and collect evaluator feedback on whether responses are in character, out of character, or invalid
+- Export the completed scenarios and generate a simulation-quality report
+
+Characters are not added to production unless they pass the quality thresholds defined by `character-release-policy.yml`. In practice this means they must clear release gates such as:
+
+- **In-character fidelity (ICF)** — whether the character stays behaviorally consistent across scenarios
+- **Scenario coverage** — whether the evaluation meaningfully covers the pressure-category space intended for that character
+
+Because these evaluations are fingerprinted against the character sheet, prompt, and model configuration, changes to any of those components require re-evaluation.
+
+For the end-to-end workflow, see [Custom Characters](../user_guide/advanced.md#custom-characters).
+
+## Gameplay Quality
+
+Gameplay is guardrailed using low-latency validator ensembles that fail quickly when a player turn or simulator turn violates engine or game rules.
+
+## Validator Architecture
+
+### 1. Motivation
 
 The turn-based role-playing simulation involves two characters — a **player character (PC)** controlled by the human participant (or, in some experimental conditions, by an LLM surrogate), and a **non-player character (NPC)** controlled entirely by the simulator. LLMs are responsible for nearly all components of interaction including the generation of a player's output, scene description, and determining valid outputs. When a single LLM call drives both the adjudication of the player's action and the narration of the response (the "updater") without guardrails, the simulation is subject to well-known failure modes that contaminate the interaction data collected by the engine.
 
@@ -29,7 +54,7 @@ A note on terminology used throughout the rest of this document:
 - **Player output** — text the player submits, written from the PC's perspective (e.g. `"I pull on the door."`). The player is the agent producing it; the PC is the in-fiction subject.
 - **Simulator response** — everything the simulator produces in reaction: adjudication of the player's action, scene / world updates, and optionally an NPC action or speech act in the same immediate beat. The NPC is not the only thing the simulator outputs — it is one possible component of the simulation engine's response.
 
-## 2. Architectural overview
+### 2. Architectural overview
 
 <img src="../assets/validator_architecture.png" width="400" height="400">
 
@@ -50,7 +75,7 @@ The diagram above walks through one full turn of the control flow:
 | `DEFAULT_SIMULATOR_TURN_VALIDATORS` | `prompts.py` | Ordered list of simulator-response rule templates |
 | `SimulatorClient` | `ai_client.py` | Single integration point used by game `step()` methods — renders prompts, runs validators, retries the updater, records failures |
 
-## 3. Data model
+### 3. Data model
 
 Validation outcomes flow end-to-end via four record types (`ai_client.py`):
 
@@ -89,7 +114,7 @@ class ParsedSimulatorResponse(NamedTuple):
 
 `SimulatorTurnResult` is what `step()` returns to the game loop. `SimulatorValidationFailure` is the record persisted to MongoDB via the event recorder, so every violation is queryable post-hoc for per-rule failure-rate analysis.
 
-## 4. Validator prompts
+### 4. Validator prompts
 
 Each validator is a single system prompt that instructs the judge LLM to emit strict JSON:
 
@@ -105,7 +130,7 @@ Every validator prompt is rendered by `_render_prompt` from a shared character c
 
 The judge model is configurable per `SimulatorClient` instance (`validator_model`). The default is the same as the updater (`DEFAULT_MODEL = "openai/gpt-5-mini"` at `ai_client.py`), but swapping in a cheaper/faster judge is a single constructor argument.
 
-## 5. Symmetric rules (applied to both PC and NPC)
+### 5. Symmetric rules (applied to both PC and NPC)
 
 Three rule concerns apply symmetrically to both sides of the interaction, with a PC-side version applied to every submitted player output and an NPC-side version applied to every simulator response. These three concerns form the core of the validator design: they protect against the same underlying failure modes regardless of which side is generating the content.
 
@@ -119,7 +144,7 @@ Three rule concerns apply symmetrically to both sides of the interaction, with a
 
 The player-input set (`DEFAULT_PLAYER_TURN_VALIDATORS` in `prompts.py`) runs the three PC-side rules above as a fan-out on every submitted player output. Validators race in parallel; as soon as any rule fails, remaining in-flight rules are cancelled and awaited. This is a deliberate cost/latency optimisation: any single failure vetoes the turn, so no information is lost by cancelling the others. In the pass case the full fan-out cost is paid, but latency is bounded by the slowest single judge rather than the sum.
 
-## 6. Simulator-only rules
+### 6. Simulator-only rules
 
 Three further rules apply only to the simulator response, because they govern how the simulated world is presented to the player and how the objective is pursued — concerns with no PC-side analog:
 
@@ -131,7 +156,7 @@ Three further rules apply only to the simulator response, because they govern ho
 
 The simulator-response set (`DEFAULT_SIMULATOR_TURN_VALIDATORS` in `prompts.py`) combines the three NPC-side rules from §5 with the three simulator-only rules above, and gates every updater-generated response — across adjudication, scene updates, and any NPC action or speech act the response may contain.
 
-## 7. Prompt design conventions
+### 7. Prompt design conventions
 
 Every validator prompt follows a consistent skeleton, which is the discipline that keeps the set stable:
 
@@ -145,7 +170,7 @@ Every validator prompt follows a consistent skeleton, which is the discipline th
 
 The result is that each rule prompt reads like a compact spec — short, self-contained, and debuggable in isolation. When a rule misfires, a single string can be edited and re-run without touching any other rule.
 
-## 8. Testing and maintaining validator quality
+### 8. Testing and maintaining validator quality
 
 The validator architecture above describes *what* the rules are and *how* they fan out at runtime; this section covers *how we know they still work* after a model swap, prompt edit, or rule revision.
 
@@ -184,13 +209,13 @@ Validator-level quality (this document) and character-level quality are two dist
 
 A character that scores well on ICF still depends on the validator ensemble being calibrated correctly, which is why both layers are exercised when a model is swapped or a character is updated.
 
-## 9. Concerns and future work
+### 9. Concerns and future work
 
 1. **Judge-model drift.** Rule firing rates depend on the judge model's behaviour. Any upstream model change could silently alter the false-positive / false-negative mix. The fixture suite in §8 catches drift on the labelled cases, but rule firing rates on production transcripts can still shift in ways not covered by the fixtures — sampling and re-grading a slice of recorded sessions after each model bump is the natural complement.
 2. **Rule independence assumption.** The fan-out design assumes rules are roughly independent. Observed co-firing on narrative content suggests partial overlap, especially between `VALID-PERCEPTION-BOUNDARY`, `VALID-AUTHORITY-BOUNDARY-SIMULATOR`, and `VALID-ADJUDICATION`. A principled merging (e.g. a single judge seeing all relevant rules with composite reasoning) may outperform the current fan-out on high-overlap cases, at the cost of losing per-rule attribution.
 3. **Cost.** Each turn incurs up to `len(player_validators)` parallel judge calls plus a sequential walk of `simulator_validators` (bounded by first-failure), plus one updater call and optionally one retry. First-failure cancellation keeps the failure case cheap; the pass case pays the full fan-out and is worth quantifying on a per-game basis before any experiment at scale.
 
-## 10. File reference
+### 10. File reference
 
 - Core classes: `dcs_simulation_engine/games/ai_client.py`
     - `SimulatorValidationFailure`, `SimulatorComponentResult`, `SimulatorTurnResult`, `ParsedSimulatorResponse` — result types

--- a/docs/user_guide/advanced.md
+++ b/docs/user_guide/advanced.md
@@ -53,7 +53,7 @@ This creates a scaffolded scenarios file in `dcs_utils/data/character_scenarios/
 Then run HITL updates while the DCS server is running:
 
 ```bash
-dcs-utils hitl update <character_hid>
+dcs admin hitl update <character_hid>
 ```
 
 `hitl update` can:

--- a/docs/user_guide/advanced.md
+++ b/docs/user_guide/advanced.md
@@ -4,17 +4,17 @@
 
 ## Custom Assignment Strategies
 
-Assignment strategies control what gameplay scenario (game + characters) is available next for a player. Researchers use this to ensure that players gameplay sessions are distributed across games and characters in a way that meets their research goals. For example, a researcher might want to ensure that each player gets a balanced mix of games and characters, or that certain underrepresented characters are prioritized for assignment.
+Assignment strategies control what gameplay scenario (game + characters) is available next for a player. Researchers use this to ensure that player gameplay sessions are distributed across games and characters in a way that meets their research goals. For example, a researcher might want to ensure that each player gets a balanced mix of games and characters, or that certain underrepresented characters are prioritized for assignment.
 
-To customize assignment strategies, checkout the code and implement the `AssignmentStrategy` interface in `dcs_simulation_engine/core/assignment_strategies.py`. Then reference your strategy by name in a run configuration.
+To customize assignment strategies, check out the code and implement the `AssignmentStrategy` interface in `dcs_simulation_engine/core/assignment_strategies.py`. Then reference your strategy by name in a run configuration.
 
 ⚠️ Note: This feature is incomplete or missing.
 
 ## Custom Character Filters
 
-Character filters allow users to specify useful categories of PCs/NPCs allowed in gameplay. For example, if a user wants only neurodivergent non-player characters allows they can use the built-in `neurodivergent` filter by name.
+Character filters allow users to specify useful categories of PCs/NPCs allowed in gameplay. For example, if a user wants only neurodivergent non-player characters, they can use the built-in `neurodivergent` filter by name.
 
-To customize character filters, checkout the code and 
+To customize character filters, check out the code and:
 
 ### 1. Add the filter
 
@@ -28,37 +28,83 @@ Then run the engine with the filter referenced by name in the run config and onl
 
 ## Custom Characters
 
-To customize (add/modify) characters, checkout the codebase and use the workflow below.
+To customize (add/modify) characters, check out the codebase and use the workflow below.
 
 ### 1. Create character sheet(s)
 
-Create or modify a character sheet based on research (e.g., primary sources, expert interviews) and add it to the character to the database: `database_seeds/dev/characters.json`
+Create or modify a character sheet based on research (for example primary sources, expert interviews, or first-person experiential input) and add it to the development database: `database_seeds/dev/characters.json`.
 
-### 2. Iteratively update characters sheet(s) to meet quality thresholds
+Character sheets usually include:
 
-Use the human-in-the-loop CLI to generate scenarios and evaluate character behavior:
+- Short and long descriptions
+- Abilities, persona features, and goals
+- Structured dimensions such as origin, form, agency, substrate, and size
 
-`dcs admin hitl --help`
+### 2. Iteratively update character sheet(s) to meet quality thresholds
+
+Use the human-in-the-loop (HITL) CLI to generate scenarios and evaluate character behavior:
+
+```bash
+dcs-utils hitl create <character_hid> --db dev
+```
+
+This creates a scaffolded scenarios file in `dcs_utils/data/character_scenarios/`. Edit the prompts so they actually pressure-test the character's behavior.
+
+Then run HITL updates while the DCS server is running:
+
+```bash
+dcs-utils hitl update <character_hid>
+```
+
+`hitl update` can:
+
+- Build or rebuild scenario history
+- Generate simulator responses
+- Collect evaluator feedback on whether outputs are in character, out of character, or invalid
+
+In practice, this stage is iterative: adjust the character sheet and/or scenario prompts, rerun HITL, and keep going until the behavior looks good.
 
 > Optionally running external evaluations using `expert-evaluation.yml` and/or `select-characters.yml` run configs can be useful where you have access to domain experts that can provide feedback on character behavior. 
 
 ### 3. Generate a Simulation Quality Report
 
-Generate a simulation quality report (`dcs report <path/to/results> sim-quality --title "Character Quality Report"`) and determine if the coverage and in-character fidelity (ICF) scores are sufficient for publication 
+Export the completed HITL scenarios to a results directory:
 
-If results are insufficient go back to step 2 to improve the character sheets or adjust the thresholds in `character-release-policy.yml`. If results are sufficient, move to step 4 to publish for review.
+```bash
+dcs-utils hitl export <character_hid>
+```
+
+Then generate a simulation quality report:
+
+```bash
+dcs-utils report results results/hitl_<character_hid> --only sim-quality --title "Simulation Quality — <character_hid>"
+```
+
+Review the report and determine whether the coverage and in-character fidelity (ICF) scores are sufficient for publication.
+
+If results are insufficient, go back to step 2 and improve the character sheet and/or scenario prompts. If results are sufficient, move to step 4.
 
 ### 4. Publish for Review
 
-Publish the character (`dcs admin publish --help`)
+Publish the character evaluation results:
 
-> To propose the DCS-SE adds this character to core characters database open a PR that includes reasoning and design decisions, code changes and the quality report with scores.
+```bash
+dcs-utils admin publish characters <path-to-sim-quality-report.html>
+```
+
+Then open a PR that includes:
+
+- The character JSON changes
+- The character scenarios JSON file
+- Any evaluation artifacts that are appropriate for the current workflow, such as simulation-quality reports
+
+> To propose that DCS-SE add a character to the core character database, open a PR that includes the reasoning and design decisions, code changes, and the quality report with scores.
 
 ⸻
 
 ## Custom Games
 
-To customize games, beyond their existing exposed configuration options, checkout the codebase and use the workflow below.
+To customize games, beyond their existing exposed configuration options, check out the codebase and use the workflow below.
 
 ### 1. Implement the Game Interface
 

--- a/docs/user_guide/advanced.md
+++ b/docs/user_guide/advanced.md
@@ -71,13 +71,13 @@ In practice, this stage is iterative: adjust the character sheet and/or scenario
 Export the completed HITL scenarios to a results directory:
 
 ```bash
-dcs-utils hitl export <character_hid>
+dcs admin hitl export <character_hid>
 ```
 
 Then generate a simulation quality report:
 
 ```bash
-dcs-utils report results results/hitl_<character_hid> --only sim-quality --title "Simulation Quality — <character_hid>"
+dcs report results results/hitl_<character_hid> --only sim-quality --title "Simulation Quality — <character_hid>"
 ```
 
 Review the report and determine whether the coverage and in-character fidelity (ICF) scores are sufficient for publication.
@@ -89,7 +89,7 @@ If results are insufficient, go back to step 2 and improve the character sheet a
 Publish the character evaluation results:
 
 ```bash
-dcs-utils admin publish characters <path-to-sim-quality-report.html>
+dcs admin publish characters <path-to-sim-quality-report.html>
 ```
 
 Then open a PR that includes:

--- a/docs/user_guide/advanced.md
+++ b/docs/user_guide/advanced.md
@@ -45,7 +45,7 @@ Character sheets usually include:
 Use the human-in-the-loop (HITL) CLI to generate scenarios and evaluate character behavior:
 
 ```bash
-dcs-utils hitl create <character_hid> --db dev
+dcs admin hitl create <character_hid> --db dev
 ```
 
 This creates a scaffolded scenarios file in `dcs_utils/data/character_scenarios/`. Edit the prompts so they actually pressure-test the character's behavior.


### PR DESCRIPTION
Here are my docs updates and PR. I focused on the three areas McKinnley flagged: Design > Characters, User Guide > Advanced > Custom Characters, and Design > Simulation Quality. I also cleaned up wording and grammar in those sections for clarity. The Simulation Quality page now includes a Character Representational Quality section that explains how character behavioral quality is maintained through HITL evaluation, reporting, and release thresholds, and the Custom Characters section is updated to reflect the current CLI workflow!