### PR TITLE
[FIX] Advanced Docs OpenEvolve Update

### DIFF
--- a/docs/user_guide/advanced.md
+++ b/docs/user_guide/advanced.md
@@ -150,7 +150,126 @@ The engine exposes an API endpoint, so you do not have to use our text-based Rea
 
 This is useful for non-run-harnessed gameplay, where the client directly interacts with the engine API without using the run harness. This enables custom orchestration, AI-driven control loops, and integration into external systems or apps.
 
-TODO: Add open-evolve example
+[OpenEvolve](https://github.com/codelion/openevolve) is an evolutionary coding agent: it mutates a small "initial program" file across generations and scores each candidate with an evaluator function. To evolve a program that *plays* a game on the engine, start the engine without the UI (see [examples/run_configs/benchmark-ai.yml](https://github.com/diverse-cognitive-systems-group/dcs-simulation-engine/blob/main/examples/run_configs/benchmark-ai.yml), which sets `launch_gui: false`) and have the candidate program call the API directly (see [examples/api_usage/](https://github.com/diverse-cognitive-systems-group/dcs-simulation-engine/tree/main/examples/api_usage)).
+
+```plaintext
+[OpenEvolve controller]
+   - mutates initial_program
+   - schedules evaluations
+          │
+          ▼
+[evaluator.py: evaluate(candidate_path)]
+   - imports candidate
+   - opens APIClient → start_game(...)
+   - loops run.step(text) until done
+   - returns {"combined_score": float, ...}
+          │
+          │ HTTP + WebSocket
+          ▼
+[Simulation Engine API on :8000]
+```
+
+#### Step 1 — Drive a single game from Python
+
+The minimal non-harnessed loop uses `APIClient.start_game` (in `dcs_simulation_engine.api.client`)
+and the returned `SimulationRun` context manager. The first `step()` consumes the engine's opening
+turn; subsequent `step(text)` calls submit player input.
+
+```python
+# openevolve-run.py
+from dcs_simulation_engine.api.client import APIClient
+from dcs_simulation_engine.api.models import CreateGameRequest
+
+def play_one_game(strategy_fn, *, max_turns: int = 12) -> dict:
+    """Drive one game session end-to-end. `strategy_fn(history) -> str` is the policy."""
+    request = CreateGameRequest(
+        game="Infer Intent",
+        pc_choice=None,         # let the server pick a default-eligible PC
+        npc_choice=None,
+        source="openevolve",    # tag the session for downstream filtering
+    )
+    with APIClient(url="http://localhost:8000") as client, \
+         client.start_game(request) as run:
+        run.step()              # consume the opening turn
+        while not run.is_complete and run.turns < max_turns:
+            utterance = strategy_fn(run.history)
+            run.step(utterance)
+        return {"turns": run.turns, "exited": run.is_complete, "history": run.history}
+```
+
+#### Step 2 — Make the strategy evolvable
+
+OpenEvolve evolves whatever lives between `EVOLVE-BLOCK-START` / `EVOLVE-BLOCK-END` markers in the
+initial program file. For prompt evolution this can be as small as a strategy snippet that gets
+injected into a frozen LLM prompt template; for code evolution it is a callable.
+
+```python
+# initial_program.py
+# OpenEvolve will mutate the body of the "EVOLVE-.." block.
+
+# EVOLVE-BLOCK-START
+def choose_utterance(history: list) -> str:
+    """Return the next player utterance given prior events."""
+    return "Tell me more about what you want."
+# EVOLVE-BLOCK-END
+```
+
+#### Step 3 — Wire up the evaluator
+
+The evaluator imports the candidate, runs one or more games against the live engine, and returns
+metrics. OpenEvolve maximizes `combined_score`; additional keys become artifacts the next generation
+can be conditioned on.
+
+```python
+# evaluator.py
+import importlib.util
+
+def _load(candidate_path: str):
+    spec = importlib.util.spec_from_file_location("candidate", candidate_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+def evaluate(candidate_path: str) -> dict:
+    candidate = _load(candidate_path)
+    try:
+        result = play_one_game(candidate.choose_utterance, max_turns=12)
+    except Exception as exc:
+        return {"combined_score": 0.0, "error": str(exc)[:500]}
+
+    # Score however the experiment defines success — turn count, a Scorer LLM call,
+    # game-specific exit reason, etc. Keep `combined_score` in [0, 1].
+    score = 1.0 if result["exited"] else result["turns"] / 12
+    return {"combined_score": score, "turns": result["turns"]}
+```
+
+#### Step 4 — Run evolution
+
+A minimal config file for OpenEvolve, pointing at OpenRouter for the mutation LLM:
+
+```yaml
+# oe-config.yml
+max_iterations: 50
+llm:
+  api_base: "https://openrouter.ai/api/v1/"
+  api_key: ${OPENROUTER_API_KEY}
+  models:
+    - name: "google/gemini-2.5-flash-lite"
+      weight: 1.0
+evaluator:
+  timeout: 600
+  parallel_evaluations: 2
+```
+
+Then launch evolution from the OpenEvolve CLI against the running engine:
+
+```bash
+dcs run --config path/to/my/dcs-run-config.yml &&
+python openevolve-run.py initial_program.py evaluator.py --config oe-config.yaml --iterations 50
+```
+
+> The comprehensive and complete default OpenEvolve config file can be found at OpenEvolve's GitHub page regarding the configs – [page link](https://github.com/algorithmicsuperintelligence/openevolve/blob/main/configs/default_config.yaml).
+
 
 ### Example Unity Integration
 


### PR DESCRIPTION
- **docs(advanced):** Replace the Add open-evolve example TODO in [docs/user_guide/advanced.md](https://github.com/diverse-cognitive-systems-group/dcs-simulation-engine/pull/docs/user_guide/advanced.md) with a 4-step worked example showing how to drive the engine API directly from Python (via APIClient + SimulationRun) and slot that loop into an OpenEvolve evaluate(candidate_path) function. Includes an architecture diagram, an evolvable initial program with EVOLVE-BLOCK markers, a minimal evaluator, a config.yaml sketch, and a launch command. Points to the full reference impl in dcs-interfacing-agents/OpenEvolve/examples/llm_prompt/.docs(advanced): Replace the Add open-evolve example TODO in [docs/user_guide/advanced.md](https://github.com/diverse-cognitive-systems-group/dcs-simulation-engine/pull/docs/user_guide/advanced.md) with a 4-step worked example showing how to drive the engine API directly from Python (via APIClient + SimulationRun) and slot that loop into an OpenEvolve evaluate(candidate_path) function. Includes an architecture diagram, an evolvable initial program with EVOLVE-BLOCK markers, a minimal evaluator, a config.yaml sketch, and a launch command. Points to the full reference impl in dcs-interfacing-agents/OpenEvolve/examples/llm_prompt/.