### PR TITLE
Fix goal horizon game

### DIFF
--- a/dcs_simulation_engine/games/ai_client.py
+++ b/dcs_simulation_engine/games/ai_client.py
@@ -198,6 +198,8 @@ class ParsedSimulatorResponse(NamedTuple):
 class SimulatorClient:
     """Thin orchestrator around configurable validation and simulator advancement."""
 
+    _OPENING_SCENE_PREFIX = "Opening scene: "
+
     def __init__(
         self,
         *,
@@ -217,6 +219,7 @@ class SimulatorClient:
         self._history: list[str] = []
         self._transcript_events: list[str] = []
         self._opening_metadata: dict[str, Any] = {}
+        self._opening_scenes: list[str] = []
 
         self._player_turn_validators = (
             list(player_turn_validators) if player_turn_validators is not None else list(DEFAULT_PLAYER_TURN_VALIDATORS)
@@ -257,6 +260,7 @@ class SimulatorClient:
         """Restore conversation history from a snapshot."""
         self._history = list(history)
         self._transcript_events = list(history)
+        self._opening_scenes = self._derive_opening_scenes(self._history)
 
     def export_state(self) -> dict[str, Any]:
         """Return all mutable simulator state needed for pause/resume."""
@@ -264,6 +268,7 @@ class SimulatorClient:
             "history": list(self._history),
             "transcript_events": list(self._transcript_events),
             "opening_metadata": dict(self._opening_metadata),
+            "opening_scenes": list(self._opening_scenes),
         }
 
     def import_state(self, state: dict[str, Any]) -> None:
@@ -271,6 +276,7 @@ class SimulatorClient:
         history = state.get("history", [])
         transcript_events = state.get("transcript_events", history)
         opening_metadata = state.get("opening_metadata", {})
+        opening_scenes = state.get("opening_scenes")
 
         self._history = [str(entry) for entry in history] if isinstance(history, list) else []
         if isinstance(transcript_events, list):
@@ -278,6 +284,21 @@ class SimulatorClient:
         else:
             self._transcript_events = list(self._history)
         self._opening_metadata = dict(opening_metadata) if isinstance(opening_metadata, dict) else {}
+        if isinstance(opening_scenes, list):
+            self._opening_scenes = [str(scene) for scene in opening_scenes if str(scene).strip()]
+        else:
+            self._opening_scenes = self._derive_opening_scenes(self._history)
+
+    @classmethod
+    def _derive_opening_scenes(cls, history: list[str]) -> list[str]:
+        """Recover opening scene text from legacy history-only snapshots."""
+        scenes: list[str] = []
+        for entry in history:
+            if entry.startswith(cls._OPENING_SCENE_PREFIX):
+                scene = entry.removeprefix(cls._OPENING_SCENE_PREFIX).strip()
+                if scene:
+                    scenes.append(scene)
+        return scenes
 
     @property
     def player_turn_validators(self) -> list[str]:
@@ -336,7 +357,12 @@ class SimulatorClient:
 
     def _build_opening_scene_prompt(self) -> str:
         """Render the configured opening-scene template."""
-        return build_opener_prompt(self._pc, self._npc, template=self._opener_template)
+        return build_opener_prompt(
+            self._pc,
+            self._npc,
+            template=self._opener_template,
+            excluded_scenes=self._opening_scenes,
+        )
 
     def _build_updater_prompt(self, *, user_input: str) -> str:
         """Render the configured simulator updater prompt."""
@@ -552,6 +578,7 @@ class SimulatorClient:
         if opening.type == "error":
             raise ValueError("Opener returned an invalid JSON payload.")
         self._opening_metadata = dict(opening.metadata)
+        self._opening_scenes.append(opening.content)
         self._history.append(f"Opening scene: {opening.content}")
         self._transcript_events.append(f"Opening scene: {opening.content}")
         return opening

--- a/dcs_simulation_engine/games/const.py
+++ b/dcs_simulation_engine/games/const.py
@@ -142,6 +142,7 @@ class GoalHorizon:
 
 ---
 
+- Type `/new-scene` to start a new scene.
 - Type `/abilities` for character abilities.
 - Type `/help` at any time to see this message again.\
 """

--- a/dcs_simulation_engine/games/goal_horizon.py
+++ b/dcs_simulation_engine/games/goal_horizon.py
@@ -44,6 +44,7 @@ class GoalHorizonGame(Game):
         self._capability_prediction_confidence = ""
         self._score: dict[str, Any] = {}
         self._awaiting_confidence = False
+        self._scene_count = 1
 
     @classmethod
     def create_from_context(cls, pc: CharacterRecord, npc: CharacterRecord, **kwargs: Any) -> "GoalHorizonGame":
@@ -71,6 +72,7 @@ class GoalHorizonGame(Game):
             "capability_prediction": self._capability_prediction,
             "capability_prediction_confidence": self._capability_prediction_confidence,
             "score": dict(self._score),
+            "scene_count": self._scene_count,
         }
 
     def _import_additional_state(self, state: dict[str, Any]) -> None:
@@ -84,6 +86,7 @@ class GoalHorizonGame(Game):
         self._capability_prediction_confidence = str(state.get("capability_prediction_confidence", ""))
         score = state.get("score", {})
         self._score = dict(score) if isinstance(score, dict) else {}
+        self._scene_count = int(state.get("scene_count", 1))
 
     @property
     def capability_prediction(self) -> str:
@@ -99,6 +102,18 @@ class GoalHorizonGame(Game):
     def score(self) -> dict[str, Any]:
         """Scorer result, or empty dict."""
         return self._score
+
+    def get_command_handler(self, cmd: str):
+        """Return a handler for the given command, or None if not recognized."""
+        if cmd == "new-scene":
+            return self._handle_new_scene
+        return None
+
+    async def _handle_new_scene(self) -> AsyncIterator[GameEvent]:
+        self._scene_count += 1
+        opening = await self._engine.chat(None)
+        self._filtered_transcript_buffer.append(f"{self.OPENING_PREFIX}{opening.content}")
+        yield GameEvent.now(type="ai", content=opening.content, command_response=True)
 
     def get_help_content(self) -> str:
         """Return the /help message content."""

--- a/dcs_simulation_engine/games/prompts.py
+++ b/dcs_simulation_engine/games/prompts.py
@@ -274,7 +274,7 @@ OPENER = """You set up the scene for a text-based role-playing game. Describe ON
 - Goals: {npc_goals}
 - Example Scenes: {npc_scenarios}
 
-Rules:
+{scene_exclusion_instructions}Rules:
 - Begin with: "You enter a new space. In this space,"
 - Describe the immediate surroundings where both characters could plausibly be present.
 - Use 1–2 sentences only.
@@ -839,9 +839,37 @@ def _render_prompt(template: str, **context: object) -> str:
     return template.format(**normalized_context)
 
 
-def build_opener_prompt(pc: CharacterRecord, npc: CharacterRecord, *, template: str = OPENER) -> str:
+def _build_scene_exclusion_instructions(excluded_scenes: list[str] | None) -> str:
+    """Render optional instructions telling the opener not to repeat prior scenes."""
+    scenes = [str(scene).strip() for scene in excluded_scenes or [] if str(scene).strip()]
+    if not scenes:
+        return ""
+
+    formatted_scenes = "\n".join(f"- {scene}" for scene in scenes)
+    return (
+        "Scene Exclusion Instructions:\n"
+        "Do not reuse or closely imitate any of these previous scene setups:\n"
+        f"{formatted_scenes}\n"
+        "Generate a materially different setting, situation, and immediate context.\n\n"
+    )
+
+
+def build_opener_prompt(
+    pc: CharacterRecord,
+    npc: CharacterRecord,
+    *,
+    template: str = OPENER,
+    excluded_scenes: list[str] | None = None,
+) -> str:
     """Render the opening-scene prompt."""
-    return _render_prompt(template, **_build_character_context(pc, npc))
+    return _render_prompt(
+        template,
+        **_build_character_context(
+            pc,
+            npc,
+            scene_exclusion_instructions=_build_scene_exclusion_instructions(excluded_scenes),
+        ),
+    )
 
 
 def build_updater_prompt(

--- a/tests/functional/test_goal_horizon_simulation_flow.py
+++ b/tests/functional/test_goal_horizon_simulation_flow.py
@@ -6,6 +6,7 @@ import pytest
 from bson import ObjectId
 from dcs_simulation_engine.core.session_manager import SessionManager
 from dcs_simulation_engine.dal.mongo.const import MongoColumns
+from dcs_simulation_engine.games import ai_client
 from dcs_simulation_engine.games.ai_client import ScorerResult
 
 pytestmark = [pytest.mark.functional, pytest.mark.anyio]
@@ -99,6 +100,40 @@ async def test_goal_horizon_finish_flow_routes_follow_up_input(patch_llm_client,
     assert session.turns == 1
     assert session.game.capability_prediction == "Its goals seem bounded to immediate environmental regulation."
     assert not session.exited
+
+
+async def test_goal_horizon_new_scene_excludes_prior_openings(monkeypatch, _isolate_db_state, async_mongo_provider):
+    """The /new-scene command should ask for a materially different opener."""
+    captured_prompts: list[str] = []
+    opening_responses = [
+        '{"type": "ai", "content": "You enter a new space. In this space, a quiet lab bench waits beside a shallow dish."}',
+        '{"type": "ai", "content": "You enter a new space. In this space, a loading dock ramp blocks a rolling cart."}',
+    ]
+
+    async def fake_call_openrouter(messages, model):
+        _ = model
+        captured_prompts.append(messages[0].get("content", ""))
+        return opening_responses.pop(0)
+
+    monkeypatch.setattr(ai_client, "_call_openrouter", fake_call_openrouter)
+
+    session = await _make_session(async_mongo_provider)
+    enter_events = await session.step_async("")
+    new_scene_events = await session.step_async("/new-scene")
+
+    assert [event["type"] for event in enter_events] == ["info", "ai"]
+    assert [event["type"] for event in new_scene_events] == ["ai"]
+    assert "loading dock ramp" in new_scene_events[0]["content"]
+    assert session.game._scene_count == 2
+
+    transcript = session.game.get_transcript()
+    assert "quiet lab bench waits" in transcript
+    assert "loading dock ramp" in transcript
+    assert "--- Scene" not in transcript
+
+    assert "Scene Exclusion Instructions" not in captured_prompts[0]
+    assert "Scene Exclusion Instructions" in captured_prompts[1]
+    assert "quiet lab bench waits" in captured_prompts[1]
 
 
 async def test_goal_horizon_scoring_falls_back_on_scorer_failure(patch_llm_client, _isolate_db_state, async_mongo_provider):

--- a/tests/unit/games/test_prompts.py
+++ b/tests/unit/games/test_prompts.py
@@ -69,6 +69,22 @@ def test_build_opener_prompt_renders_character_context(character_pair) -> None:
     assert "NPC (Simulated Character)" in prompt
     assert "Player long" in prompt
     assert "NPC long" in prompt
+    assert "Scene Exclusion Instructions" not in prompt
+
+
+@pytest.mark.unit
+def test_build_opener_prompt_optionally_renders_scene_exclusions(character_pair) -> None:
+    """Opener prompt should include scene exclusions only when callers provide them."""
+    pc, npc = character_pair
+    prompt = build_opener_prompt(
+        pc,
+        npc,
+        excluded_scenes=["You enter a new space. In this space, a quiet lab bench waits."],
+    )
+
+    assert "Scene Exclusion Instructions" in prompt
+    assert "Do not reuse or closely imitate" in prompt
+    assert "a quiet lab bench waits" in prompt
 
 
 @pytest.mark.unit

--- a/tests/unit/games/test_simulator_client.py
+++ b/tests/unit/games/test_simulator_client.py
@@ -317,12 +317,46 @@ async def test_simulator_client_updater_succeeds_after_one_simulator_validation_
 
 
 @pytest.mark.unit
+@pytest.mark.anyio
+async def test_simulator_client_excludes_prior_opening_scenes_from_later_openers(
+    monkeypatch: pytest.MonkeyPatch, pc: CharacterRecord, npc: CharacterRecord
+) -> None:
+    """Later opener prompts should tell the model not to reuse earlier scenes."""
+    captured_prompts: list[str] = []
+    responses = [
+        '{"type": "ai", "content": "You enter a new space. In this space, a quiet lab bench waits."}',
+        '{"type": "ai", "content": "You enter a new space. In this space, a crowded loading dock blocks the path."}',
+    ]
+
+    async def fake_call(messages, model):
+        _ = model
+        captured_prompts.append(messages[0]["content"])
+        return responses.pop(0)
+
+    monkeypatch.setattr(ai_client, "_call_openrouter", fake_call)
+
+    client = SimulatorClient(pc=pc, npc=npc)
+
+    await client.chat(None)
+    await client.chat(None)
+
+    assert "Scene Exclusion Instructions" not in captured_prompts[0]
+    assert "Scene Exclusion Instructions" in captured_prompts[1]
+    assert "a quiet lab bench waits" in captured_prompts[1]
+    assert client._opening_scenes == [
+        "You enter a new space. In this space, a quiet lab bench waits.",
+        "You enter a new space. In this space, a crowded loading dock blocks the path.",
+    ]
+
+
+@pytest.mark.unit
 def test_simulator_client_state_round_trip_preserves_resume_context(pc: CharacterRecord, npc: CharacterRecord) -> None:
     """SimulatorClient should persist all mutable prompt context needed for resume."""
     client = SimulatorClient(pc=pc, npc=npc)
     client._history = ["Opening scene: A quiet room.", "Player (PC): I wave."]
     client._transcript_events = ["Opening scene: A quiet room.", "Player (PC): I wave.", "Simulator: The NPC nods."]
     client._opening_metadata = {"shared_goal": "Calmly solve the puzzle."}
+    client._opening_scenes = ["A quiet room."]
 
     snapshot = client.export_state()
 
@@ -333,3 +367,32 @@ def test_simulator_client_state_round_trip_preserves_resume_context(pc: Characte
     assert restored._history == client._history
     assert restored._transcript_events == client._transcript_events
     assert restored._opening_metadata == client._opening_metadata
+    assert restored._opening_scenes == client._opening_scenes
+
+
+@pytest.mark.unit
+def test_simulator_client_import_state_derives_opening_scenes_from_legacy_history(
+    pc: CharacterRecord, npc: CharacterRecord
+) -> None:
+    """Older snapshots without opening_scenes should still preserve scene avoidance after resume."""
+    client = SimulatorClient(pc=pc, npc=npc)
+
+    client.import_state(
+        {
+            "history": [
+                "Opening scene: A quiet room.",
+                "Player (PC): I wave.",
+                "Simulator: The NPC nods.",
+                "Opening scene: A busy hallway.",
+            ],
+            "transcript_events": [
+                "Opening scene: A quiet room.",
+                "Player (PC): I wave.",
+                "Simulator: The NPC nods.",
+                "Opening scene: A busy hallway.",
+            ],
+            "opening_metadata": {},
+        }
+    )
+
+    assert client._opening_scenes == ["A quiet room.", "A busy hallway."]

--- a/ui/src/routes/play/$sessionId.tsx
+++ b/ui/src/routes/play/$sessionId.tsx
@@ -40,6 +40,10 @@ const GAME_COMMANDS: Record<string, CommandSuggestion[]> = {
     { command: '/help', description: 'Show instructions.' },
     { command: '/abilities', description: 'Show character abilities.' },
     {
+      command: '/new-scene',
+      description: 'Start a new scene (characters retain memory of prior scenes).',
+    },
+    {
       command: '/finish',
       description:
         "Submit your prediction about the simulator character's capabilities and finish the game.",


### PR DESCRIPTION
Adds a new-scence command to goal horizon (with storing of past opening scenes so that repeat scenes are avoided)

Addresses issue: #165

