### PR TITLE
UI cleanup + couple bug fixes

### DIFF
--- a/dcs_simulation_engine/api/routers/play.py
+++ b/dcs_simulation_engine/api/routers/play.py
@@ -87,6 +87,20 @@ async def _sync_run_assignment_if_needed(*, provider: Any, entry: Any) -> None:
     )
 
 
+async def _terminal_assignment_status(*, provider: Any, assignment_id: str | None) -> str | None:
+    """Return terminal run assignment status when the session is no longer playable."""
+    if assignment_id is None:
+        return None
+    getter = getattr(provider, "get_assignment", None)
+    if getter is None:
+        return None
+    assignment = await maybe_await(getter(assignment_id=assignment_id))
+    status_value = getattr(assignment, "status", None) if assignment is not None else None
+    if status_value in {"completed", "interrupted"}:
+        return status_value
+    return None
+
+
 async def _send_error(websocket: WebSocket, detail: str) -> None:
     """Send a standardized error frame to the client."""
     await websocket.send_json(WSErrorFrame(detail=detail).model_dump(mode="json"))
@@ -369,6 +383,18 @@ async def play_ws(websocket: WebSocket, session_id: str) -> None:
 
         if entry.player_id != player.id:
             await _send_error(websocket, "Unauthorized for this session")
+            await websocket.close()
+            return
+
+        if _session_status(entry.status, entry.manager.exited) == "closed":
+            await _send_error(websocket, "Session is closed")
+            await websocket.close()
+            return
+
+        assignment_status = await _terminal_assignment_status(provider=provider, assignment_id=entry.assignment_id)
+        if assignment_status is not None:
+            registry.close(session_id)
+            await _send_error(websocket, "Session is closed")
             await websocket.close()
             return
 

--- a/dcs_simulation_engine/core/engine_run_manager.py
+++ b/dcs_simulation_engine/core/engine_run_manager.py
@@ -488,6 +488,8 @@ class EngineRunManager:
             raise ValueError("No matching assignment is available for this player.")
         if assignment.status == "completed":
             raise ValueError("Completed assignments cannot be resumed.")
+        if assignment.status == "interrupted":
+            raise ValueError("Interrupted assignments cannot be resumed.")
         config = cls.get_run_config()
         assignments = await maybe_await(provider.list_assignments(player_id=player.id))
         pending_groups = await cls.pending_form_groups_async(

--- a/dcs_simulation_engine/games/ai_client.py
+++ b/dcs_simulation_engine/games/ai_client.py
@@ -71,7 +71,7 @@ async def _call_openrouter(messages: list[dict[str, str]], model: str) -> str:
         response = await client.post(
             _CHAT_ENDPOINT,
             headers={"Authorization": f"Bearer {api_key}"},
-            json={"model": model, "messages": messages},
+            json={"model": model, "messages": messages, "max_completion_tokens": 1024},
             timeout=None,
         )
         if response.is_error:

--- a/tests/functional/test_server.py
+++ b/tests/functional/test_server.py
@@ -1111,6 +1111,12 @@ def test_run_websocket_close_updates_assignment_status(client: TestClient) -> No
     kwargs = handle_terminal_mock.await_args.kwargs
     assert kwargs["assignment_id"] == "asg-live-1"
 
+    with client.websocket_connect(f"/api/play/game/{session_id}/ws") as ws:
+        ws.send_json({"type": "auth", "api_key": "valid-key"})
+        error_frame = ws.receive_json()
+        assert error_frame["type"] == "error"
+        assert error_frame["detail"] == "Session is closed"
+
 
 @pytest.mark.functional
 def test_run_multiple_assignments_can_each_be_resumed(

--- a/tests/functional/test_usability_flow.py
+++ b/tests/functional/test_usability_flow.py
@@ -72,3 +72,39 @@ def test_usability_run_forms_assignments_and_sessions_flow(patch_llm_client, asy
     assert final_setup["assignment_completed"] is True
     assert final_setup["pending_form_groups"] == []
     assert final_setup["next_assignment"]["mode"] == "none"
+
+
+def test_interrupted_run_assignment_cannot_start_or_resume_session(patch_llm_client, async_mongo_provider) -> None:
+    """Interrupted gameplay should remain terminal at the session-start boundary."""
+    _ = patch_llm_client
+    config = load_run_config("usability")
+
+    with example_client(async_mongo_provider, config) as client:
+        auth_payload = register_player(client)
+        headers = auth_headers(auth_payload)
+
+        setup_payload = run_setup(client, headers)
+        submit_pending_group(client, headers, setup_payload, event="before_all_assignments")
+
+        setup_payload = run_setup(client, headers)
+        assignment = choose_or_locked_assignment(client, headers, setup_payload)
+        create_run_session(client, headers, assignment_id=assignment["assignment_id"])
+
+        asyncio.run(
+            async_mongo_provider.update_assignment_status(
+                assignment_id=assignment["assignment_id"],
+                status="interrupted",
+            )
+        )
+
+        response = client.post(
+            "/api/run/sessions",
+            headers=headers,
+            json={
+                "source": "run",
+                "assignment_id": assignment["assignment_id"],
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Interrupted assignments cannot be resumed."

--- a/ui/src/hooks/use-session-websocket.ts
+++ b/ui/src/hooks/use-session-websocket.ts
@@ -28,8 +28,6 @@ export interface ChatMessage {
   feedback?: MessageFeedback
   // Unix timestamp (ms) set when the message is added to the list.
   timestamp: number
-  // True for messages replayed from a previous session on resume.
-  isHistorical?: boolean
 }
 
 type WsState = 'connecting' | 'auth' | 'ready' | 'closed' | 'error'
@@ -133,7 +131,6 @@ export function useSessionWebSocket(sessionId: string) {
             content: frame.content,
             eventId: typeof frame.event_id === 'string' ? frame.event_id : undefined,
             timestamp: Date.now(),
-            isHistorical: true,
           },
         ])
       }

--- a/ui/src/hooks/use-session-websocket.ts
+++ b/ui/src/hooks/use-session-websocket.ts
@@ -32,7 +32,8 @@ export interface ChatMessage {
 
 type WsState = 'connecting' | 'auth' | 'ready' | 'closed' | 'error'
 
-export function useSessionWebSocket(sessionId: string) {
+export function useSessionWebSocket(sessionId: string, options: { enabled?: boolean } = {}) {
+  const enabled = options.enabled ?? true
   // useState holds reactive values that cause the component to re-render when they change.
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [wsState, setWsState] = useState<WsState>('connecting')
@@ -65,6 +66,12 @@ export function useSessionWebSocket(sessionId: string) {
   // takes over. We also only close sockets that are still CONNECTING or OPEN.
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — only re-connect on sessionId change
   useEffect(() => {
+    if (!enabled) {
+      setWsState('closed')
+      setWaiting(false)
+      return
+    }
+
     let cancelled = false
 
     const socket = new WebSocket(resolveWebSocketUrl(`/api/play/game/${sessionId}/ws`))
@@ -190,7 +197,7 @@ export function useSessionWebSocket(sessionId: string) {
         socket.close()
       }
     }
-  }, [sessionId])
+  }, [sessionId, enabled])
 
   // useCallback memoizes the function so its reference stays stable across renders,
   // which matters here because sendTurn is used in JSX event handlers.

--- a/ui/src/routes/play/$sessionId.tsx
+++ b/ui/src/routes/play/$sessionId.tsx
@@ -201,9 +201,17 @@ function PlayPage() {
     setSelectedCommandIndex((current) => Math.min(current, commandSuggestions.length - 1))
   }, [commandSuggestions])
 
+  const isConnecting = wsState === 'connecting' || wsState === 'auth'
+  const isError = wsState === 'error'
+  const isClosed = wsState === 'closed' || exited
+  // Allow drafting at all times except terminal states (closed/error).
+  const inputDisabled = isClosed || isError
+  const gameReady = wsState === 'ready' && turns > 0 && !isReplaying
+  const canSubmitTurn = gameReady && !waiting && !exited && !inputDisabled && !!input.trim()
+
   function submitInput() {
     const text = input.trim()
-    if (!text || exited || wsState !== 'ready' || waiting) return
+    if (!canSubmitTurn) return
     sendTurn(text)
     setInput('')
   }
@@ -236,7 +244,7 @@ function PlayPage() {
       const selectedSuggestion = commandSuggestions[selectedCommandIndex] ?? commandSuggestions[0]
       const typedCommand = input.trim().toLowerCase()
       const canAutocompleteWithEnter =
-        selectedSuggestion && typedCommand !== selectedSuggestion.command
+        canSubmitTurn && selectedSuggestion && typedCommand !== selectedSuggestion.command
 
       if (e.key === 'Tab' || (e.key === 'Enter' && !e.shiftKey && canAutocompleteWithEnter)) {
         e.preventDefault()
@@ -248,10 +256,11 @@ function PlayPage() {
     }
 
     // Enter alone submits; Shift+Enter inserts a newline.
-    const canSubmit = !waiting && !exited && wsState === 'ready' && !!input.trim()
-    if (e.key === 'Enter' && !e.shiftKey && canSubmit) {
+    if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
-      submitInput()
+      if (canSubmitTurn) {
+        submitInput()
+      }
     }
   }
 
@@ -329,15 +338,7 @@ function PlayPage() {
     }
   }
 
-  const isConnecting = wsState === 'connecting' || wsState === 'auth'
-  const isError = wsState === 'error'
-  const isClosed = wsState === 'closed' || exited
-  // Allow drafting at all times except terminal states (closed/error).
-  const inputDisabled = isClosed || isError
-
-  // Send is blocked while the simulation is loading or awaiting the next turn response.
-  // turns === 0 means the initial simulator message hasn't arrived yet (game not started).
-  const sendDisabled = !input.trim() || inputDisabled || isConnecting || waiting || turns === 0
+  const sendDisabled = !canSubmitTurn
   const thinkingMessages = longThinking ? longThinkingMessageQueue : thinkingMessageQueue
   const thinkingMessage =
     thinkingMessages[thinkingMessageIndex % thinkingMessages.length] ?? THINKING_MESSAGES[0]

--- a/ui/src/routes/play/$sessionId.tsx
+++ b/ui/src/routes/play/$sessionId.tsx
@@ -102,14 +102,6 @@ function normalizeGameName(value: string): string {
   return value.replace(/[\s_-]+/g, '').toLowerCase()
 }
 
-function formatElapsed(seconds: number): string {
-  const h = Math.floor(seconds / 3600)
-  const m = Math.floor((seconds % 3600) / 60)
-  const s = seconds % 60
-  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
-  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
-}
-
 function shuffleMessages(messages: string[]): string[] {
   const shuffled = [...messages]
   for (let i = shuffled.length - 1; i > 0; i -= 1) {
@@ -144,7 +136,6 @@ function PlayPage() {
   const [input, setInput] = useState('')
   const [feedbackPendingEventId, setFeedbackPendingEventId] = useState<string | null>(null)
   const [selectedCommandIndex, setSelectedCommandIndex] = useState(0)
-  const [elapsedSeconds, setElapsedSeconds] = useState(0)
   const [thinkingMessageIndex, setThinkingMessageIndex] = useState(0)
   const [longThinking, setLongThinking] = useState(false)
   const [thinkingMessageQueue, setThinkingMessageQueue] = useState(() =>
@@ -153,7 +144,6 @@ function PlayPage() {
   const [longThinkingMessageQueue, setLongThinkingMessageQueue] = useState(() =>
     shuffleMessages(LONG_THINKING_MESSAGES),
   )
-  const startTimeRef = useRef(Date.now())
   // bottomRef is attached to a sentinel div at the end of the message list so we can
   // scroll it into view whenever a new message arrives.
   const bottomRef = useRef<HTMLDivElement>(null)
@@ -190,16 +180,6 @@ function PlayPage() {
       window.clearTimeout(longThinkingTimeoutId)
     }
   }, [waiting])
-
-  // Elapsed timer — counts up every second until the session ends.
-  const sessionEnded = wsState === 'closed' || exited
-  useEffect(() => {
-    if (sessionEnded) return
-    const id = setInterval(() => {
-      setElapsedSeconds(Math.floor((Date.now() - startTimeRef.current) / 1000))
-    }, 1000)
-    return () => clearInterval(id)
-  }, [sessionEnded])
 
   const availableCommands = useMemo(() => {
     return GAME_COMMANDS[normalizeGameName(gameName ?? '')] ?? []
@@ -369,9 +349,6 @@ function PlayPage() {
           <h1 className="font-semibold text-sm">{gameName || 'Game'}</h1>
           <Badge variant="outline" className="text-xs">
             Turn {turns}
-          </Badge>
-          <Badge variant="outline" className="text-xs tabular-nums">
-            {formatElapsed(elapsedSeconds)}
           </Badge>
           {pcHid && (
             <Badge variant="secondary" className="text-xs" title="Your character">

--- a/ui/src/routes/play/$sessionId.tsx
+++ b/ui/src/routes/play/$sessionId.tsx
@@ -1,6 +1,7 @@
 // Live play page at /play/:sessionId. Connects to the game session via WebSocket,
 // renders the chat transcript, and lets the player submit turns.
 
+import { useQuery } from '@tanstack/react-query'
 import { createRoute, useNavigate, useParams, useSearch } from '@tanstack/react-router'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import {
@@ -8,14 +9,14 @@ import {
   useSubmitSessionEventFeedbackApiSessionsSessionIdEventsEventIdFeedbackPost,
 } from '@/api/generated'
 import type { SubmitSessionEventFeedbackResponse } from '@/api/generated/model'
-import { HttpError } from '@/api/http'
+import { HttpError, httpClient } from '@/api/http'
 import { ChatMessageBubble } from '@/components/chat-message'
 import { FatalErrorOverlay } from '@/components/fatal-error-overlay'
 import { ThemeToggle } from '@/components/theme-toggle'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
-import type { MessageFeedback } from '@/hooks/use-session-websocket'
+import type { ChatMessage, EventType, MessageFeedback } from '@/hooks/use-session-websocket'
 import { useSessionWebSocket } from '@/hooks/use-session-websocket'
 import { unwrapOrvalData } from '@/lib/orval-response'
 import { getServerConfig } from '@/lib/server-config'
@@ -57,6 +58,41 @@ const LONG_THINKING_MESSAGES = [
 interface CommandSuggestion {
   command: string
   description: string
+}
+
+interface ReconstructionSession {
+  session_id?: string
+  status?: string
+  game_name?: string
+  pc_hid?: string | null
+  npc_hid?: string | null
+  turns_completed?: number | null
+}
+
+interface ReconstructionFeedback {
+  liked?: boolean
+  comment?: string | null
+  doesnt_make_sense?: boolean
+  out_of_character?: boolean
+  other?: boolean
+  submitted_at?: string
+}
+
+interface ReconstructionEvent {
+  seq?: number
+  event_id?: string
+  event_ts?: string
+  direction?: string
+  event_type?: string
+  content?: string
+  turn_index?: number
+  visible_to_user?: boolean
+  feedback?: ReconstructionFeedback | null
+}
+
+interface SessionReconstruction {
+  session?: ReconstructionSession
+  events?: ReconstructionEvent[]
 }
 
 const GAME_COMMANDS: Record<string, CommandSuggestion[]> = {
@@ -102,6 +138,69 @@ function normalizeGameName(value: string): string {
   return value.replace(/[\s_-]+/g, '').toLowerCase()
 }
 
+function isTerminalSessionStatus(status: string | undefined): boolean {
+  return status === 'closed' || status === 'error'
+}
+
+function feedbackFromReconstruction(
+  feedback: ReconstructionFeedback | null | undefined,
+): MessageFeedback | undefined {
+  if (!feedback || typeof feedback.liked !== 'boolean') return undefined
+  return {
+    liked: feedback.liked,
+    comment: feedback.comment ?? '',
+    doesntMakeSense: Boolean(feedback.doesnt_make_sense),
+    outOfCharacter: Boolean(feedback.out_of_character),
+    other: Boolean(feedback.other),
+    submittedAt: feedback.submitted_at ?? new Date().toISOString(),
+  }
+}
+
+function eventTypeFromReconstruction(event: ReconstructionEvent): EventType {
+  const eventType = String(event.event_type ?? 'info').toLowerCase()
+  const direction = String(event.direction ?? 'outbound').toLowerCase()
+
+  if (eventType === 'message') return direction === 'inbound' ? 'info' : 'ai'
+  if (eventType === 'error') return 'error'
+  if (eventType === 'warning') return 'warning'
+  return 'info'
+}
+
+function messagesFromReconstruction(
+  reconstruction: SessionReconstruction | undefined,
+): ChatMessage[] {
+  return (reconstruction?.events ?? [])
+    .filter((event) => {
+      const eventType = String(event.event_type ?? '').toLowerCase()
+      if (event.visible_to_user === false) return false
+      return !['session_start', 'session_end'].includes(eventType)
+    })
+    .map((event, index) => {
+      const direction = String(event.direction ?? 'outbound').toLowerCase()
+      return {
+        id: event.event_id ?? `${event.seq ?? index}`,
+        role: direction === 'inbound' ? 'user' : 'ai',
+        eventType: eventTypeFromReconstruction(event),
+        content: event.content ?? '',
+        eventId: event.event_id,
+        feedback: feedbackFromReconstruction(event.feedback),
+        timestamp: event.event_ts ? new Date(event.event_ts).getTime() : Date.now(),
+      }
+    })
+}
+
+function turnsFromReconstruction(reconstruction: SessionReconstruction | undefined): number {
+  const turnsCompleted = reconstruction?.session?.turns_completed
+  if (typeof turnsCompleted === 'number') return turnsCompleted
+
+  return Math.max(
+    0,
+    ...(reconstruction?.events ?? []).map((event) =>
+      typeof event.turn_index === 'number' ? event.turn_index : 0,
+    ),
+  )
+}
+
 function shuffleMessages(messages: string[]): string[] {
   const shuffled = [...messages]
   for (let i = shuffled.length - 1; i > 0; i -= 1) {
@@ -117,6 +216,13 @@ function PlayPage() {
   const { sessionId } = useParams({ from: '/play/$sessionId' })
   const { gameName, runName } = useSearch({ from: '/play/$sessionId' })
   const navigate = useNavigate()
+  const { data: reconstruction, isLoading: reconstructionLoading } = useQuery({
+    queryKey: ['session-reconstruction', sessionId],
+    queryFn: () => httpClient<SessionReconstruction>(`/api/sessions/${sessionId}/reconstruction`),
+    retry: false,
+  })
+  const terminalReconstruction = isTerminalSessionStatus(reconstruction?.session?.status)
+  const shouldConnectWebSocket = !reconstructionLoading && !terminalReconstruction
   // useSessionWebSocket opens the WebSocket connection and returns reactive state plus
   // action callbacks; see hooks/use-session-websocket.ts for the protocol details.
   const {
@@ -131,7 +237,7 @@ function PlayPage() {
     hasGameFeedback,
     sendTurn,
     setMessageFeedback,
-  } = useSessionWebSocket(sessionId)
+  } = useSessionWebSocket(sessionId, { enabled: shouldConnectWebSocket })
 
   const [input, setInput] = useState('')
   const [feedbackPendingEventId, setFeedbackPendingEventId] = useState<string | null>(null)
@@ -156,7 +262,7 @@ function PlayPage() {
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional — scroll on both new messages and waiting-state change
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [messages, waiting])
+  }, [messages, reconstruction, waiting])
 
   useEffect(() => {
     setThinkingMessageIndex(0)
@@ -201,13 +307,25 @@ function PlayPage() {
     setSelectedCommandIndex((current) => Math.min(current, commandSuggestions.length - 1))
   }, [commandSuggestions])
 
-  const isConnecting = wsState === 'connecting' || wsState === 'auth'
+  const readOnlyMessages = useMemo(
+    () => messagesFromReconstruction(reconstruction),
+    [reconstruction],
+  )
+  const displayMessages = terminalReconstruction ? readOnlyMessages : messages
+  const displayTurns = terminalReconstruction ? turnsFromReconstruction(reconstruction) : turns
+  const displayExited = terminalReconstruction || exited
+  const displayPcHid = terminalReconstruction ? (reconstruction?.session?.pc_hid ?? null) : pcHid
+  const displayNpcHid = terminalReconstruction ? (reconstruction?.session?.npc_hid ?? null) : npcHid
+
+  const isConnecting =
+    !terminalReconstruction &&
+    (reconstructionLoading || wsState === 'connecting' || wsState === 'auth')
   const isError = wsState === 'error'
-  const isClosed = wsState === 'closed' || exited
+  const isClosed = terminalReconstruction || wsState === 'closed' || exited
   // Allow drafting at all times except terminal states (closed/error).
   const inputDisabled = isClosed || isError
-  const gameReady = wsState === 'ready' && turns > 0 && !isReplaying
-  const canSubmitTurn = gameReady && !waiting && !exited && !inputDisabled && !!input.trim()
+  const gameReady = shouldConnectWebSocket && wsState === 'ready' && turns > 0 && !isReplaying
+  const canSubmitTurn = gameReady && !waiting && !displayExited && !inputDisabled && !!input.trim()
 
   function submitInput() {
     const text = input.trim()
@@ -349,16 +467,16 @@ function PlayPage() {
         <div className="flex items-center gap-3 flex-wrap">
           <h1 className="font-semibold text-sm">{gameName || 'Game'}</h1>
           <Badge variant="outline" className="text-xs">
-            Turn {turns}
+            Turn {displayTurns}
           </Badge>
-          {pcHid && (
+          {displayPcHid && (
             <Badge variant="secondary" className="text-xs" title="Your character">
-              Player Character: {pcHid}
+              Player Character: {displayPcHid}
             </Badge>
           )}
-          {npcHid && (
+          {displayNpcHid && (
             <Badge variant="secondary" className="text-xs" title="Simulator character">
-              Simulator Character: {npcHid}
+              Simulator Character: {displayNpcHid}
             </Badge>
           )}
           {isClosed && (
@@ -374,7 +492,7 @@ function PlayPage() {
 
       <div className="flex-1 overflow-y-auto px-4 py-4">
         <div className="mx-auto w-full max-w-[96vw] sm:max-w-[92vw] lg:max-w-[86vw] xl:max-w-[80vw] space-y-3">
-          {(isConnecting || (turns === 0 && wsState === 'ready')) && (
+          {(isConnecting || (!terminalReconstruction && turns === 0 && wsState === 'ready')) && (
             <div className="flex flex-col items-center gap-3 py-8 text-muted-foreground">
               {/* CSS-only spinner: a bordered circle with one colored arc, rotated by animation */}
               <div className="w-6 h-6 rounded-full border-2 border-muted/70 border-t-primary animate-spin" />
@@ -389,7 +507,7 @@ function PlayPage() {
             />
           )}
 
-          {messages.map((msg) => (
+          {displayMessages.map((msg) => (
             <ChatMessageBubble
               key={msg.id}
               message={msg}
@@ -423,7 +541,7 @@ function PlayPage() {
             </div>
           )}
 
-          {exited && (
+          {displayExited && (
             <div className="flex flex-col items-center gap-3 py-4 text-center">
               <div>
                 <Badge variant="secondary">Simulation ended</Badge>

--- a/ui/src/routes/play/$sessionId.tsx
+++ b/ui/src/routes/play/$sessionId.tsx
@@ -389,31 +389,15 @@ function PlayPage() {
             />
           )}
 
-          {messages.map((msg, idx) => {
-            // Insert a "Session resumed" separator between the last historical message
-            // and the first live message, once replay has completed.
-            const isLastHistorical =
-              !isReplaying &&
-              msg.isHistorical &&
-              (idx === messages.length - 1 || !messages[idx + 1].isHistorical)
-            return (
-              <div key={msg.id} className={msg.isHistorical ? 'opacity-60' : undefined}>
-                <ChatMessageBubble
-                  message={msg}
-                  feedbackPending={!!msg.eventId && feedbackPendingEventId === msg.eventId}
-                  onSubmitFeedback={handleSubmitFeedback}
-                  onClearFeedback={handleClearFeedback}
-                />
-                {isLastHistorical && (
-                  <div className="flex items-center gap-3 py-3 text-xs text-muted-foreground">
-                    <div className="flex-1 border-t border-dashed" />
-                    <span>Session resumed</span>
-                    <div className="flex-1 border-t border-dashed" />
-                  </div>
-                )}
-              </div>
-            )
-          })}
+          {messages.map((msg) => (
+            <ChatMessageBubble
+              key={msg.id}
+              message={msg}
+              feedbackPending={!!msg.eventId && feedbackPendingEventId === msg.eventId}
+              onSubmitFeedback={handleSubmitFeedback}
+              onClearFeedback={handleClearFeedback}
+            />
+          ))}
 
           {/* Animated "thinking" indicator shown while waiting for the AI response */}
           {waiting && (

--- a/ui/src/routes/play/$sessionId.tsx
+++ b/ui/src/routes/play/$sessionId.tsx
@@ -18,6 +18,7 @@ import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import type { ChatMessage, EventType, MessageFeedback } from '@/hooks/use-session-websocket'
 import { useSessionWebSocket } from '@/hooks/use-session-websocket'
+import { ensureAnonymousAuth } from '@/lib/auth'
 import { unwrapOrvalData } from '@/lib/orval-response'
 import { getServerConfig } from '@/lib/server-config'
 import { cn } from '@/lib/utils'
@@ -618,7 +619,9 @@ export const playRoute = createRoute({
     const serverConfig = await getServerConfig()
     if (serverConfig.authentication_required) {
       await requireAuth()
+      return
     }
+    await ensureAnonymousAuth()
   },
   component: PlayPage,
 })

--- a/ui/src/routes/run.tsx
+++ b/ui/src/routes/run.tsx
@@ -446,11 +446,17 @@ function playerCharacterLabel(item: Pick<AssignmentSummary, 'player_character_na
 }
 
 function isAssignmentContinuable(status: AssignmentSummary['status']) {
-  return status !== 'completed'
+  return status === 'assigned' || status === 'in_progress'
 }
 
-function assignmentActionLabel(_status: AssignmentSummary['status']) {
-  return 'Continue'
+function assignmentActionLabel(status: AssignmentSummary['status']) {
+  return status === 'assigned' ? 'Start' : 'Continue'
+}
+
+function assignmentStatusLabel(status: AssignmentSummary['status']) {
+  if (status === 'assigned') return 'Ready'
+  if (status === 'in_progress') return 'In Progress'
+  return 'Done'
 }
 
 function FormOverlay(props: {
@@ -991,8 +997,14 @@ function RunPage() {
                       </div>
                     </div>
                     <div className="flex flex-wrap items-center gap-2 sm:justify-end">
-                      <Badge variant={assignment.status === 'completed' ? 'default' : 'secondary'}>
-                        {titleCase(assignment.status)}
+                      <Badge
+                        variant={
+                          assignment.status === 'completed' || assignment.status === 'interrupted'
+                            ? 'default'
+                            : 'secondary'
+                        }
+                      >
+                        {assignmentStatusLabel(assignment.status)}
                       </Badge>
                       {isAssignmentContinuable(assignment.status) && (
                         <Button

--- a/ui/src/routes/run.tsx
+++ b/ui/src/routes/run.tsx
@@ -707,9 +707,6 @@ function RunPage() {
     (nextAssignment.reason === 'unavailable' || nextAssignment.reason === 'quota_closed')
 
   const lockedAssignment = nextAssignment?.mode === 'locked' ? nextAssignment.assignment : null
-  const unfinishedAssignmentCount = (data?.assignments ?? []).filter(
-    (assignment) => assignment.status !== 'completed',
-  ).length
 
   useEffect(() => {
     const nextForms = data?.pending_form_groups?.[0]?.forms ?? []
@@ -903,9 +900,6 @@ function RunPage() {
           <CardHeader>
             <div className="flex flex-wrap items-center justify-between gap-2">
               <CardTitle>Gameplay Sessions</CardTitle>
-              {unfinishedAssignmentCount > 0 && (
-                <Badge variant="secondary">{unfinishedAssignmentCount} unfinished</Badge>
-              )}
             </div>
             <CardDescription>Active and completed gameplay sessions.</CardDescription>
           </CardHeader>

--- a/ui/tests/README.md
+++ b/ui/tests/README.md
@@ -1,0 +1,16 @@
+# UI Test Backlog
+
+When frontend tests are added, include tests for:
+
+- Players can draft text while a game is loading.
+- Players cannot submit text with the Send button until the game has loaded and it is their turn.
+- Players cannot submit text with Enter until the game has loaded and it is their turn.
+- Players cannot submit slash commands before the game has loaded.
+- Slash command autocomplete cannot use Enter before the game has loaded.
+- Resumed sessions stay submit-disabled during replay and enable after replay completes.
+- Input submission is disabled while waiting for the simulator response.
+- Interruped or errored games cant be resumed
+- Resumed sessions show the correct message/events
+- Refresh button doesn't change anything - just reloads current session/state
+- Back button ...
+- Fwd button ...

--- a/ui/tests/README.md
+++ b/ui/tests/README.md
@@ -15,6 +15,8 @@ When frontend tests are added, include tests for:
 - Errored or closed saved game session IDs are cleared instead of showing Resume Game.
 - Refreshing a completed, interrupted, or errored play page restores the ended read-only transcript instead of restarting gameplay.
 - Opening the same live play session in a second tab shows that the session is already open elsewhere.
+- Directly opening a play URL in anonymous mode creates anonymous auth before connecting the WebSocket.
+- Directly opening a play URL in registration-required mode gates on sign-in instead of creating anonymous auth.
 - Resumed sessions show the correct message/events
 - Refresh button doesn't change anything - just reloads current session/state
 - Back button ...

--- a/ui/tests/README.md
+++ b/ui/tests/README.md
@@ -9,7 +9,12 @@ When frontend tests are added, include tests for:
 - Slash command autocomplete cannot use Enter before the game has loaded.
 - Resumed sessions stay submit-disabled during replay and enable after replay completes.
 - Input submission is disabled while waiting for the simulator response.
-- Interruped or errored games cant be resumed
+- Interrupted or errored games can't be resumed.
+- Completed, interrupted, and errored run assignments display Done.
+- Interrupted run assignments show their status without a Start, Continue, or Resume action.
+- Errored or closed saved game session IDs are cleared instead of showing Resume Game.
+- Refreshing a completed, interrupted, or errored play page restores the ended read-only transcript instead of restarting gameplay.
+- Opening the same live play session in a second tab shows that the session is already open elsewhere.
 - Resumed sessions show the correct message/events
 - Refresh button doesn't change anything - just reloads current session/state
 - Back button ...


### PR DESCRIPTION
# UI clean up

1) Remove UI timer: UI's elapsed gameplay time display doesn't work after pause/resume PR #173. Because it tends to cluttter the top bar anyway we decided to just remove it. Removing it also keeps the player interfaces more consistent between players using different clients.

2) Fix can submit text before game loads (issue #131): implemented as a minimal front-end change. Not convinced guardrailing the backend is long-term useful esp if future work may add non-strict turn-based interactions.

3) Resume currently shows/displays previous resumed events as greyed out but prelim usability feedback suggested just show it as it was. 

4) UI allows directly resuming the same errored/closed gameplay session. Updates UI to only allow continuation when not completed or errored states. (issue #214)

5) Removes "X unfinished" indicator at top right per prelim usability feedback. Specifically the feedback was that unless it informs an action just get rid of it.


## Notes: 

### 1. Includes OR 402 bug fix

Also included in this PR by necessity is a small OpenRouter fix - #231 captures the long term fix needs but I added a reasonable cap for our needs as a minimal fix for now.

Bug/diagnosis: OpenRouter was rejecting the uncapped request because it reserved the model’s default max output budget, not because the UI/prompt was actually enormous.

The minimal real fix is to keep an explicit `max_completion_tokens` in the backend OpenRouter payload. 

### 2. Includes a ui/auth bug fix

Opening another tab with when playing a session with anonymous auth also restarts.

## Test

Test with manual GUI testing since jest tests aren't written yet. 

- run engine with demo.yml (anon auth) and usability.yml (auth) and try 
    + submitting text + commands before game loads
    + refresh, back, foward buttons
    + max out invalid turn attempts to get interuppted state and try resuming
    + open same session (copy/past url) in another tab and make sure blocked

---