### PR TITLE
Fix prod release manifest 

### DIFF
--- a/dcs_simulation_engine/dal/mongo/admin.py
+++ b/dcs_simulation_engine/dal/mongo/admin.py
@@ -17,6 +17,8 @@ from pymongo.collection import Collection
 from pymongo.database import Database
 from pymongo.errors import CollectionInvalid
 
+SEED_METADATA_FILENAMES = {"__manifest__.json", "release_manifest.json"}
+
 
 class MongoAdmin:
     """Administrative operations over a specific Mongo DB handle."""
@@ -143,7 +145,7 @@ class MongoAdmin:
 
         total_inserted = 0
         for seed_file in seed_files:
-            if seed_file.name == "__manifest__.json" or seed_file.name.endswith(".__indexes__.json"):
+            if seed_file.name in SEED_METADATA_FILENAMES or seed_file.name.endswith(".__indexes__.json"):
                 logger.debug("Skipping metadata seed file {}", seed_file.name)
                 continue
             collection_name = seed_file.stem

--- a/tests/unit/dal/test_mongo_provider_admin.py
+++ b/tests/unit/dal/test_mongo_provider_admin.py
@@ -93,6 +93,29 @@ async def test_seed_database_drops_and_replaces_collections(async_mongo_provider
     assert db["widgets"].find_one({})["x"] == 99
 
 
+async def test_seed_database_skips_release_manifest_metadata(async_mongo_provider, tmp_path):
+    """Prod seed directories may include release_manifest.json without creating a collection."""
+    db = async_mongo_provider.get_db()
+    (tmp_path / "widgets.json").write_text('[{"x": 99}]', encoding="utf-8")
+    (tmp_path / "release_manifest.json").write_text(
+        json.dumps(
+            {
+                "policy_version": "character-release-policy-v1",
+                "engine_version": "dcs-se@0.1.0",
+                "generated_at": "",
+                "approved_characters": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    total = MongoAdmin(db=db).seed_database(seed_dir=tmp_path)
+
+    assert total == 1
+    assert db["widgets"].count_documents({}) == 1
+    assert "release_manifest" not in db.list_collection_names()
+
+
 async def test_seed_database_restores_default_indexes_after_drop(async_mongo_provider, tmp_path):
     """seed_database reapplies baseline indexes after collection drops."""
     db = async_mongo_provider.get_db()


### PR DESCRIPTION
# Fix remote deploy from prod bug

Addresses #222

The introduction of a release_manifest.json introduced a bug in CLI's remote deploy from prod that needs fixing.

`Unsupported JSON structure ... Expected array, NDJSON, or object with 'documents'.`

## Changes
- makes the release manifest ignored by mongo seeding