### PR TITLE
feat: surface assignment errors in engine status summary

### DIFF
--- a/dcs_simulation_engine/api/models.py
+++ b/dcs_simulation_engine/api/models.py
@@ -168,6 +168,7 @@ class GameStatusResponse(BaseModel):
     total: int
     completed: int
     in_progress: int
+    errored: int = 0
 
 
 class RunStatusResponse(BaseModel):

--- a/dcs_simulation_engine/api/routers/remote.py
+++ b/dcs_simulation_engine/api/routers/remote.py
@@ -83,6 +83,7 @@ def _status_response(status_payload: dict) -> RunStatusResponse:
                 total=int(counts["total"]),
                 completed=int(counts["completed"]),
                 in_progress=int(counts["in_progress"]),
+                errored=int(counts.get("errored", 0)),
             )
             for game_name, counts in dict(status_payload["per_game"]).items()
         },

--- a/dcs_simulation_engine/cli/commands/engine.py
+++ b/dcs_simulation_engine/cli/commands/engine.py
@@ -755,7 +755,9 @@ def _print_status(ctx: typer.Context, payload: dict, *, api_port: int, ui_port: 
     total = run_status.get("total")
     completed = run_status.get("completed")
     if isinstance(total, int) and isinstance(completed, int):
-        echo(ctx, f"Assignments: {completed} / {total} completed")
+        errored_total = sum(game.get("errored", 0) for game in (run_status.get("per_game") or {}).values())
+        error_summary = f" ({errored_total} errored)" if errored_total > 0 else ""
+        echo(ctx, f"Assignments: {completed} / {total} completed{error_summary}")
     if "is_open" in run_status:
         echo(ctx, f"Open: {'yes' if run_status['is_open'] else 'no'}")
 
@@ -764,10 +766,12 @@ def _print_status(ctx: typer.Context, payload: dict, *, api_port: int, ui_port: 
         echo(ctx, "")
         echo(ctx, "Per game:")
         for game_name, counts in sorted(per_game.items()):
+            errored = counts.get("errored", 0)
+            error_msg = f", {errored} errored" if errored > 0 else ""
             echo(
                 ctx,
                 f"  {game_name}: {counts.get('completed', 0)} / {counts.get('total', 0)} completed, "
-                f"{counts.get('in_progress', 0)} in progress",
+                f"{counts.get('in_progress', 0)} in progress{error_msg}",
             )
 
 

--- a/dcs_simulation_engine/core/assignment_strategies/common.py
+++ b/dcs_simulation_engine/core/assignment_strategies/common.py
@@ -91,6 +91,10 @@ class CandidateAssignmentStrategy:
             provider=provider,
             statuses=["in_progress"],
         )
+        errored_players_by_game = await self._players_by_game(
+            provider=provider,
+            statuses=["interrupted"],
+        )
         counted_players_by_game = await self._players_by_game(
             provider=provider,
             statuses=["in_progress", "completed"],
@@ -103,6 +107,7 @@ class CandidateAssignmentStrategy:
                 "total": quota_count,
                 "completed": len(completed_players_by_game.get(game_name, set())),
                 "in_progress": len(in_progress_players_by_game.get(game_name, set())),
+                "errored": len(errored_players_by_game.get(game_name, set())),
             }
 
         if quota is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,8 +172,10 @@ include = ["autoplay*", "dcs_simulation_engine*"]
 [dependency-groups]
 dev = [
   "matplotlib>=3.10.8",
+  "mongomock>=4.3.0",
   "plotly>=6.6.0",
   "py-spy>=0.4.1",
+  "pytest-cov>=7.0.0",
   "pytest-xdist>=3.8.0",
   "seaborn>=0.13.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -705,8 +705,10 @@ notebooks = [
 [package.dev-dependencies]
 dev = [
     { name = "matplotlib" },
+    { name = "mongomock" },
     { name = "plotly" },
     { name = "py-spy" },
+    { name = "pytest-cov" },
     { name = "pytest-xdist" },
     { name = "seaborn" },
 ]
@@ -764,8 +766,10 @@ provides-extras = ["dev", "notebooks"]
 [package.metadata.requires-dev]
 dev = [
     { name = "matplotlib", specifier = ">=3.10.8" },
+    { name = "mongomock", specifier = ">=4.3.0" },
     { name = "plotly", specifier = ">=6.6.0" },
     { name = "py-spy", specifier = ">=0.4.1" },
+    { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "seaborn", specifier = ">=0.13.2" },
 ]


### PR DESCRIPTION
This PR addresses #236 by surfacing errored/interrupted assignment states in the dcs engine status CLI output.

### Changes:
- **CLI**: Updated _print_status to include an aggregate error count in the top-level summary and per-game details.
- **Backend**: Modified CandidateAssignmentStrategy.compute_status_async to fetch and count interrupted assignments as errored.
- **API**: Updated RunStatusResponse and GameStatusResponse models to include the errored field.
- **Environment**: Added mongomock and pytest-cov to dev dependencies to support local unit testing.

Verified locally with pytest (all 34 relevant tests passing).

Fixes #236