### PR TITLE
Add package-release Github Action

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -1,0 +1,173 @@
+# Release Checklist
+# 1. Update `[project].version` in `pyproject.toml`.
+# 2. Merge the version change to `main`.
+# 3. Create and push a matching release tag
+
+name: Package Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_ref:
+        description: "Release tag to publish, for example v0.1.0"
+        required: true
+        type: string
+      version:
+        description: "Package version to publish, matching pyproject.toml"
+        required: true
+        type: string
+
+run-name: "Release ${{ inputs.version }} from ${{ inputs.target_ref }}"
+
+permissions:
+  contents: read
+
+jobs:
+  release-package:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.target_ref }}
+
+      - name: Validate release inputs
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+          TARGET_REF: ${{ inputs.target_ref }}
+        run: |
+          python3 - <<'PY'
+          import os
+          import tomllib
+          from pathlib import Path
+
+          version = os.environ["RELEASE_VERSION"].strip()
+          target_ref = os.environ["TARGET_REF"].strip()
+          project = tomllib.loads(Path("pyproject.toml").read_text())["project"]
+          project_version = project["version"]
+
+          if not version:
+              raise SystemExit("Release version is required")
+          if not target_ref:
+              raise SystemExit("Target ref is required")
+          if project_version != version:
+              raise SystemExit(
+                  f"Release version {version!r} does not match pyproject.toml version {project_version!r}"
+              )
+
+          expected_tag = f"v{version}"
+          allowed_refs = {expected_tag, f"refs/tags/{expected_tag}"}
+          if target_ref not in allowed_refs:
+              raise SystemExit(
+                  f"Target ref {target_ref!r} must be the matching release tag {expected_tag!r}"
+              )
+          PY
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install Python dependencies
+        run: uv sync --extra dev
+
+      - name: Install bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Build UI
+        run: |
+          cd ui
+          bun install --frozen-lockfile
+          bun run build
+
+      - name: Stage package assets
+        run: uv run python scripts/stage_package_assets.py
+
+      - name: Build package artifacts
+        run: uv build --sdist --wheel
+
+      - name: Verify packaged assets
+        run: |
+          wheel="$(ls dist/*.whl)"
+          uv run python scripts/check_package_artifact.py "$wheel"
+
+      - name: Smoke test installed wheel
+        run: |
+          repo_root="$PWD"
+          smoke_cwd="$(mktemp -d)"
+          smoke_venv="$(mktemp -d)"
+          uv run python -m venv "$smoke_venv"
+          "$smoke_venv/bin/python" -m pip install --upgrade pip
+          "$smoke_venv/bin/python" -m pip install --force-reinstall dist/*.whl
+          cd "$smoke_cwd"
+          PYTHONPATH="" "$smoke_venv/bin/dcs" --help
+          PYTHONPATH="" "$smoke_venv/bin/dcs" engine --help
+          PYTHONPATH="" "$smoke_venv/bin/python" - <<'PY'
+          import importlib.resources as resources
+
+          root = resources.files("dcs_simulation_engine").joinpath("package_assets")
+          required = [
+              "compose.yml",
+              "docker/api.dockerfile",
+              "docker/db.dockerfile",
+              "docker/ui.dockerfile",
+              "examples/run_configs/demo.yml",
+              "database_seeds/dev/characters.json",
+              "ui_dist/index.html",
+          ]
+          missing = [path for path in required if not root.joinpath(path).is_file()]
+          if missing:
+              raise SystemExit(f"Missing installed package assets: {missing}")
+          PY
+          PYTHONPATH="" "$smoke_venv/bin/dcs" report coverage --db dev
+          test -f "$smoke_cwd/reports/character_coverage_dev.html"
+          PYTHONPATH="" "$smoke_venv/bin/dcs" report results "$repo_root/tests/data/example_results" --only metadata --report-path "$smoke_cwd/report.html"
+          test -f "$smoke_cwd/report.html"
+          PYTHONPATH="" DCS_ENGINE_ASSETS_DIR="$smoke_cwd/engine-assets" "$smoke_venv/bin/python" - <<'PY'
+          from pathlib import Path
+
+          from dcs_simulation_engine.cli.commands import engine
+          from dcs_simulation_engine.utils.assets import resolve_assets
+
+          assets = resolve_assets(Path.cwd())
+          if assets.mode != "package":
+              raise SystemExit(f"Expected package assets outside the repo, got {assets.mode!r}")
+
+          materialized = engine._materialize_engine_assets(assets)
+          required = [
+              materialized.compose_file,
+              materialized.docker_dir / "api.dockerfile",
+              materialized.docker_dir / "db.dockerfile",
+              materialized.docker_dir / "ui.dockerfile",
+              materialized.root / "dcs_simulation_engine" / "cli" / "app.py",
+              materialized.default_run_config,
+              materialized.ui_dist_dir / "index.html",
+          ]
+          missing = [str(path) for path in required if not path.is_file()]
+          if missing:
+              raise SystemExit(f"Missing materialized engine assets: {missing}")
+          PY
+          set +e
+          PYTHONPATH="" "$smoke_venv/bin/dcs" hitl create NA --db dev > "$smoke_cwd/hitl.out" 2>&1
+          hitl_exit=$?
+          PYTHONPATH="" "$smoke_venv/bin/dcs" publish characters missing-report.html > "$smoke_cwd/publish.out" 2>&1
+          publish_exit=$?
+          set -e
+          test "$hitl_exit" -eq 1
+          test "$publish_exit" -eq 1
+          grep -q "currently available only from a repository" "$smoke_cwd/hitl.out"
+          grep -q "currently available only from a repository" "$smoke_cwd/publish.out"
+
+      - name: Upload package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dcs-simulation-engine-dist
+          path: dist/*
+          if-no-files-found: error
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ license-files = ["LICENSE"]
 name = "dcs-simulation-engine"
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.1.0"
+version = "0.4.0"
 
 # Installs all testing dependencies needed when pytest runs. Do NOT put
 # runtime dependencies here. These libraries will not be included when


### PR DESCRIPTION
Currently we have a github action for building the pip package (package-build.yml) however nothing for releasing. This PR adds a `package-release.yml` action that is manually triggered when we want to release a new version of the package to PyPI.

- Starts as `workflow_dispatch` only
- Requires a target/ref/version input
- Builds the package using same steps as package-build.yml
- Publishes with `pypa/gh-action-pypi-publish`
- Uses `PYPI_API_TOKEN`